### PR TITLE
Issue #41: re-style the shouty box and allow it to be dismissed

### DIFF
--- a/DDDEastAnglia/App_Start/BundleConfig.cs
+++ b/DDDEastAnglia/App_Start/BundleConfig.cs
@@ -8,7 +8,8 @@ namespace DDDEastAnglia
         public static void RegisterBundles(BundleCollection bundles)
         {
             bundles.Add(new ScriptBundle("~/bundles/jquery").Include(
-                        "~/Scripts/jquery-{version}.js", "~/Scripts/jquery.cookie.js"));
+                        "~/Scripts/jquery-{version}.js", 
+                        "~/Scripts/jquery.cookie.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/jqueryui").Include(
                         "~/Scripts/jquery-ui-{version}.js"));

--- a/DDDEastAnglia/App_Start/BundleConfig.cs
+++ b/DDDEastAnglia/App_Start/BundleConfig.cs
@@ -8,7 +8,7 @@ namespace DDDEastAnglia
         public static void RegisterBundles(BundleCollection bundles)
         {
             bundles.Add(new ScriptBundle("~/bundles/jquery").Include(
-                        "~/Scripts/jquery-{version}.js"));
+                        "~/Scripts/jquery-{version}.js", "~/Scripts/jquery.cookie.js"));
 
             bundles.Add(new ScriptBundle("~/bundles/jqueryui").Include(
                         "~/Scripts/jquery-ui-{version}.js"));

--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -236,11 +236,11 @@ fieldset {
 }
 
 #notifications-banner a:hover {
-    color: greenyellow;
+    color: #eee;
 }
 
 #notifications-banner .dismiss {
-    border: 2px solid white;
+    border: 2px solid #ccc;
     padding: 0 6px;
     cursor: pointer;
     float: right;

--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -215,23 +215,27 @@ fieldset {
     padding-right: 10px;
 }
 
-.banner {
+#notifications-banner {
     color: white;
-    font-weight: bold;
-    font-size: 18px;
-    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.75);
-    background-color: #006000;
-    background-image: linear-gradient(to bottom, #00b000, #006000);
-    border-radius: 10px;
-    padding: 15px;
-    margin: 30px 0 30px 0;
+    background-color: #008600;
+    text-shadow: 0 1px 1px black;
+    padding: 10px 20px 10px 20px;
+    margin: 0;
+    display: none;
+    border-bottom: 1px solid #777777;
 }
 
-.banner a {
-    color: white;
+#notifications-banner p {
+    margin: 0;
 }
 
-.banner a:hover {
+#notifications-banner a {
+    color: white;
+    text-decoration: none;
+    border-bottom: 1px solid white;
+}
+
+#notifications-banner a:hover {
     color: greenyellow;
 }
 

--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -239,6 +239,21 @@ fieldset {
     color: greenyellow;
 }
 
+#notifications-banner .dismiss {
+    border: 2px solid white;
+    padding: 0 6px;
+    cursor: pointer;
+    float: right;
+}
+
+#notifications-banner .dismiss a,
+#notifications-banner .dismiss a:hover {
+    color: white;
+    font-weight: bold;
+    text-decoration: none;
+    border: 0;
+}
+
 a i {
     text-decoration: none;
 }

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Models\SessionDisplayModel.cs" />
     <Compile Include="Models\SessionTweetLink.cs" />
     <Compile Include="Models\SpeakerDisplayModel.cs" />
+    <Content Include="Scripts\jquery.cookie.js" />
     <Content Include="Scripts\tweetbutton.js" />
     <Compile Include="ProfileController.generated.cs">
       <DependentUpon>T4MVC.tt</DependentUpon>

--- a/DDDEastAnglia/DataAccess/DataModel/Event.cs
+++ b/DDDEastAnglia/DataAccess/DataModel/Event.cs
@@ -64,8 +64,8 @@ namespace DDDEastAnglia.DataAccess.DataModel
         {
             PreConferenceAgendaItem votingStart;
             PreConferenceAgendaItem votingEnd;
-            if (_items.TryGetValue(DateType.SubmissionStarts, out votingStart)
-                && _items.TryGetValue(DateType.SubmissionEnds, out votingEnd))
+            if (_items.TryGetValue(DateType.VotingStarts, out votingStart)
+                && _items.TryGetValue(DateType.VotingEnds, out votingEnd))
             {
                 return votingStart.Date <= date
                        && date <= votingEnd.Date;

--- a/DDDEastAnglia/DataAccess/DataModel/Event.cs
+++ b/DDDEastAnglia/DataAccess/DataModel/Event.cs
@@ -64,8 +64,8 @@ namespace DDDEastAnglia.DataAccess.DataModel
         {
             PreConferenceAgendaItem votingStart;
             PreConferenceAgendaItem votingEnd;
-            if (_items.TryGetValue(DateType.VotingStarts, out votingStart)
-                && _items.TryGetValue(DateType.VotingEnds, out votingEnd))
+            if (_items.TryGetValue(DateType.SubmissionStarts, out votingStart)
+                && _items.TryGetValue(DateType.SubmissionEnds, out votingEnd))
             {
                 return votingStart.Date <= date
                        && date <= votingEnd.Date;

--- a/DDDEastAnglia/Scripts/jquery.cookie.js
+++ b/DDDEastAnglia/Scripts/jquery.cookie.js
@@ -1,0 +1,90 @@
+/*!
+ * jQuery Cookie Plugin v1.3.1
+ * https://github.com/carhartl/jquery-cookie
+ *
+ * Copyright 2013 Klaus Hartl
+ * Released under the MIT license
+ */
+(function ($, document, undefined) {
+
+	var pluses = /\+/g;
+
+	function raw(s) {
+		return s;
+	}
+
+	function decoded(s) {
+		return unRfc2068(decodeURIComponent(s.replace(pluses, ' ')));
+	}
+
+	function unRfc2068(value) {
+		if (value.indexOf('"') === 0) {
+			// This is a quoted cookie as according to RFC2068, unescape
+			value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+		}
+		return value;
+	}
+
+	function fromJSON(value) {
+		return config.json ? JSON.parse(value) : value;
+	}
+
+	var config = $.cookie = function (key, value, options) {
+
+		// write
+		if (value !== undefined) {
+			options = $.extend({}, config.defaults, options);
+
+			if (value === null) {
+				options.expires = -1;
+			}
+
+			if (typeof options.expires === 'number') {
+				var days = options.expires, t = options.expires = new Date();
+				t.setDate(t.getDate() + days);
+			}
+
+			value = config.json ? JSON.stringify(value) : String(value);
+
+			return (document.cookie = [
+				encodeURIComponent(key), '=', config.raw ? value : encodeURIComponent(value),
+				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
+				options.path    ? '; path=' + options.path : '',
+				options.domain  ? '; domain=' + options.domain : '',
+				options.secure  ? '; secure' : ''
+			].join(''));
+		}
+
+		// read
+		var decode = config.raw ? raw : decoded;
+		var cookies = document.cookie.split('; ');
+		var result = key ? null : {};
+		for (var i = 0, l = cookies.length; i < l; i++) {
+			var parts = cookies[i].split('=');
+			var name = decode(parts.shift());
+			var cookie = decode(parts.join('='));
+
+			if (key && key === name) {
+				result = fromJSON(cookie);
+				break;
+			}
+
+			if (!key) {
+				result[name] = fromJSON(cookie);
+			}
+		}
+
+		return result;
+	};
+
+	config.defaults = {};
+
+	$.removeCookie = function (key, options) {
+		if ($.cookie(key) !== null) {
+			$.cookie(key, null, options);
+			return true;
+		}
+		return false;
+	};
+
+})(jQuery, document);

--- a/DDDEastAnglia/T4MVC.cs
+++ b/DDDEastAnglia/T4MVC.cs
@@ -100,6 +100,8 @@ namespace Links
         public static readonly string jquery_ui_1_10_2_js = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/jquery-ui-1.10.2.min.js") ? Url("jquery-ui-1.10.2.min.js") : Url("jquery-ui-1.10.2.js");
                       
         public static readonly string jquery_ui_1_10_2_min_js = Url("jquery-ui-1.10.2.min.js");
+        public static readonly string jquery_cookie_js = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/jquery.cookie.min.js") ? Url("jquery.cookie.min.js") : Url("jquery.cookie.js");
+                      
         public static readonly string jquery_unobtrusive_ajax_js = T4MVCHelpers.IsProduction() && T4Extensions.FileExists(URLPATH + "/jquery.unobtrusive-ajax.min.js") ? Url("jquery.unobtrusive-ajax.min.js") : Url("jquery.unobtrusive-ajax.js");
                       
         public static readonly string jquery_unobtrusive_ajax_min_js = Url("jquery.unobtrusive-ajax.min.js");

--- a/DDDEastAnglia/Views/Home/Index.cshtml
+++ b/DDDEastAnglia/Views/Home/Index.cshtml
@@ -2,11 +2,6 @@
     ViewBag.Title = "Home Page";
 }
 
-@section featured
-{
-    @Html.Partial("_Banner")
-}
-
 <div class="row-fluid">
     <div class="span12">
         <h1>Welcome to DDD East Anglia!</h1>

--- a/DDDEastAnglia/Views/Session/Index.cshtml
+++ b/DDDEastAnglia/Views/Session/Index.cshtml
@@ -10,7 +10,7 @@
 
 @if (new EventRepository().Get("DDDEA2013").CanSubmit())
 {
-    <p>Session submission is now open. If you would like to speak at <span class="dddea">DDD East Anglia</span>, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
+    <p>Session submission is now open. If you would like to speak at @Html.DDDEastAnglia(), please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
 }
 
 @foreach (var session in Model)

--- a/DDDEastAnglia/Views/Session/Index.cshtml
+++ b/DDDEastAnglia/Views/Session/Index.cshtml
@@ -5,11 +5,6 @@
     ViewBag.Title = "Sessions";
 }
 
-@section featured
-{
-    @Html.Partial("_Banner")
-}
-
 <h2>Sessions</h2>
 
 @foreach (var session in Model)

--- a/DDDEastAnglia/Views/Session/Index.cshtml
+++ b/DDDEastAnglia/Views/Session/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@using DDDEastAnglia.Models
+﻿@using DDDEastAnglia.DataAccess
+@using DDDEastAnglia.Models
 @model IEnumerable<SessionDisplayModel>
 
 @{
@@ -6,6 +7,11 @@
 }
 
 <h2>Sessions</h2>
+
+@if (new EventRepository().Get("DDDEA2013").CanSubmit())
+{
+    <p>Session submission is now open. If you would like to speak at <span class="dddea">DDD East Anglia</span>, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
+}
 
 @foreach (var session in Model)
 {

--- a/DDDEastAnglia/Views/Shared/_Banner.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Banner.cshtml
@@ -12,14 +12,14 @@
 @if (@dddevent.CanSubmit())
 {
     <div id="notifications-banner" expires-on="@submissionEnds.Date.ToString("R")">
-        <span class="dismiss"><a title="Dismiss this notification">X</a></span>
+        <span class="dismiss"><a href="#" title="Dismiss this notification">X</a></span>
         <p>Session submission is now open. If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
     </div>                                
 }
 else if (@dddevent.CanVote())
 {
     <div id="notifications-banner" expires-on="@votingEnds.Date.ToString("R")">
-        <span class="dismiss"><a title="Dismiss this notification">X</a></span>
+        <span class="dismiss"><a href="#" title="Dismiss this notification">X</a></span>
         <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at DDD East Anglia.</p>
     </div>                                
 }

--- a/DDDEastAnglia/Views/Shared/_Banner.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Banner.cshtml
@@ -3,12 +3,14 @@
 @if (new EventRepository().Get("DDDEA2013").CanSubmit())
 {
     <div id="notifications-banner">
+        <span class="dismiss"><a title="Dismiss this notification">X</a></span>
         <p>Session submission is now open. If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
     </div>                                
 }
 else if (new EventRepository().Get("DDDEA2013").CanVote())
 {
     <div id="notifications-banner">
+        <span class="dismiss"><a title="Dismiss this notification">X</a></span>
         <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at <span class="dddea">DDD East Anglia</span>.</p>
     </div>                                
 }

--- a/DDDEastAnglia/Views/Shared/_Banner.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Banner.cshtml
@@ -1,20 +1,14 @@
 ﻿@using DDDEastAnglia.DataAccess
 
-<div class="row-fluid">
-    @if (new EventRepository().Get("DDDEA2013").CanSubmit())
-    {
-        <div class="banner">
-            <p>Session submission is now open.</p>
-    
-            <p>If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
-        </div>                                
-    }
-    else if (new EventRepository().Get("DDDEA2013").CanVote())
-    {
-        <div class="banner">
-            <p>Session voting is now open.</p>
-    
-            <p>Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at <span class="dddea">DDD East Anglia</span>.</p>
-        </div>                                
-    }
-</div>
+@if (new EventRepository().Get("DDDEA2013").CanSubmit())
+{
+    <div id="notifications-banner">
+        <p>Session submission is now open. If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
+    </div>                                
+}
+else if (new EventRepository().Get("DDDEA2013").CanVote())
+{
+    <div id="notifications-banner">
+        <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at <span class="dddea">DDD East Anglia</span>.</p>
+    </div>                                
+}

--- a/DDDEastAnglia/Views/Shared/_Banner.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Banner.cshtml
@@ -12,14 +12,14 @@
 @if (@dddevent.CanSubmit())
 {
     <div id="notifications-banner" data-expires="@submissionEnds.Date.ToString("R")">
-        <span class="dismiss"><a href="#" title="Dismiss this notification">X</a></span>
+        <span class="dismiss"><a href="#" title="Dismiss this notification">&times;</a></span>
         <p>Session submission is now open. If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
     </div>                                
 }
 else if (@dddevent.CanVote())
 {
     <div id="notifications-banner" data-expires="@votingEnds.Date.ToString("R")">
-        <span class="dismiss"><a href="#" title="Dismiss this notification">X</a></span>
+        <span class="dismiss"><a href="#" title="Dismiss this notification">&times;</a></span>
         <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at DDD East Anglia.</p>
     </div>                                
 }

--- a/DDDEastAnglia/Views/Shared/_Banner.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Banner.cshtml
@@ -1,16 +1,25 @@
 ﻿@using DDDEastAnglia.DataAccess
+@using DDDEastAnglia.DataAccess.DataModel
 
-@if (new EventRepository().Get("DDDEA2013").CanSubmit())
+@{
+    var eventRepository = new EventRepository();
+    var dddevent = eventRepository.Get("DDDEA2013");
+
+    var submissionEnds = dddevent.PreConferenceAgenda.First(i => i.DateType == DateType.SubmissionEnds);
+    var votingEnds = dddevent.PreConferenceAgenda.First(i => i.DateType == DateType.VotingEnds);
+}
+
+@if (@dddevent.CanSubmit())
 {
-    <div id="notifications-banner">
+    <div id="notifications-banner" expires-on="@submissionEnds.Date.ToString("R")">
         <span class="dismiss"><a title="Dismiss this notification">X</a></span>
         <p>Session submission is now open. If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
     </div>                                
 }
-else if (new EventRepository().Get("DDDEA2013").CanVote())
+else if (@dddevent.CanVote())
 {
-    <div id="notifications-banner">
+    <div id="notifications-banner" expires-on="@votingEnds.Date.ToString("R")">
         <span class="dismiss"><a title="Dismiss this notification">X</a></span>
-        <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at <span class="dddea">DDD East Anglia</span>.</p>
+        <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at DDD East Anglia.</p>
     </div>                                
 }

--- a/DDDEastAnglia/Views/Shared/_Banner.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Banner.cshtml
@@ -11,14 +11,14 @@
 
 @if (@dddevent.CanSubmit())
 {
-    <div id="notifications-banner" expires-on="@submissionEnds.Date.ToString("R")">
+    <div id="notifications-banner" data-expires="@submissionEnds.Date.ToString("R")">
         <span class="dismiss"><a href="#" title="Dismiss this notification">X</a></span>
         <p>Session submission is now open. If you would like to speak at DDD East Anglia, please @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
     </div>                                
 }
 else if (@dddevent.CanVote())
 {
-    <div id="notifications-banner" expires-on="@votingEnds.Date.ToString("R")">
+    <div id="notifications-banner" data-expires="@votingEnds.Date.ToString("R")">
         <span class="dismiss"><a href="#" title="Dismiss this notification">X</a></span>
         <p>Session voting is now open. Please @Html.ActionLink("vote on the sessions", "Vote", "Session") you would like to see at DDD East Anglia.</p>
     </div>                                

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -152,7 +152,7 @@
                     var setEventChangeDate = new Date(setEventChangeDateStr);
 
                     if (setEventChangeDate < eventChangeDate) {
-                        @{/* if the date in the cookie is less than the date on the banner, the user dismissed an older banner */}
+                        @* if the date in the cookie is less than the date on the banner, the user dismissed an older banner *@
                         $.removeCookie('notification-dismissed');
                     }
 

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -144,25 +144,27 @@
         
         <script language="javascript">
             $(document).ready(function () {
-                if ($("#notifications-banner").length) {
-                    var eventChangeDateStr = $("#notifications-banner").attr("data-expires");
-                    var eventChangeDate = new Date(eventChangeDateStr);
-                    var setEventChangeDate = new Date($.cookie("notification-dismissed"));
+                if ($("#notifications-banner").length <= 0) {
+                    return;
+                }
+                
+                var eventChangeDateStr = $("#notifications-banner").attr("data-expires");
+                var eventChangeDate = new Date(eventChangeDateStr);
+                var setEventChangeDate = new Date($.cookie("notification-dismissed"));
 
-                    if (setEventChangeDate < eventChangeDate) {
-                        @* if the date in the cookie is less than the date on the banner, the user dismissed an older banner *@
-                        $.removeCookie('notification-dismissed');
-                    }
+                if (setEventChangeDate < eventChangeDate) {
+                    @* if the date in the cookie is less than the date on the banner, the user dismissed an older banner *@
+                    $.removeCookie('notification-dismissed');
+                }
 
-                    var keepHidden = $.cookie('notification-dismissed');
+                var keepHidden = $.cookie('notification-dismissed');
 
-                    if (!keepHidden) {
-                        $("#notifications-banner").slideDown("slow");
-                        $(".dismiss").click(function() {
-                            $("#notifications-banner").slideUp("fast");
-                            $.cookie("notification-dismissed", eventChangeDateStr, { expires: 90 });
-                        });
-                    }
+                if (!keepHidden) {
+                    $("#notifications-banner").slideDown("slow");
+                    $(".dismiss").click(function() {
+                        $("#notifications-banner").slideUp("fast");
+                        $.cookie("notification-dismissed", eventChangeDateStr, { expires: 90 });
+                    });
                 }
             });
         </script>     

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -143,11 +143,29 @@
         @RenderSection("scripts", required: false)
         
         <script language="javascript">
-            $(document).ready(function() {
-                $("#notifications-banner").slideDown("slow");
-                $(".dismiss").click(function() {
-                    $("#notifications-banner").slideUp("fast");
-                });
+            $(document).ready(function () {
+                if ($("#notifications-banner").length) {
+                    var eventChangeDateStr = $("#notifications-banner").attr("expires-on");
+                    var eventChangeDate = new Date(eventChangeDateStr);
+
+                    var setEventChangeDateStr = $.cookie("notification-dismissed");
+                    var setEventChangeDate = new Date(setEventChangeDateStr);
+
+                    if (setEventChangeDate < eventChangeDate) {
+                        @{/* if the date in the cookie is less than the date on the banner, the user dismissed an older banner */}
+                        $.removeCookie('notification-dismissed');
+                    }
+
+                    var keepHidden = $.cookie('notification-dismissed');
+
+                    if (!keepHidden) {
+                        $("#notifications-banner").slideDown("slow");
+                        $(".dismiss").click(function() {
+                            $("#notifications-banner").slideUp("fast");
+                            $.cookie("notification-dismissed", eventChangeDateStr, { expires: 90 });
+                        });
+                    }
+                }
             });
         </script>     
 });

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -145,11 +145,9 @@
         <script language="javascript">
             $(document).ready(function () {
                 if ($("#notifications-banner").length) {
-                    var eventChangeDateStr = $("#notifications-banner").attr("expires-on");
+                    var eventChangeDateStr = $("#notifications-banner").attr("data-expires");
                     var eventChangeDate = new Date(eventChangeDateStr);
-
-                    var setEventChangeDateStr = $.cookie("notification-dismissed");
-                    var setEventChangeDate = new Date(setEventChangeDateStr);
+                    var setEventChangeDate = new Date($.cookie("notification-dismissed"));
 
                     if (setEventChangeDate < eventChangeDate) {
                         @* if the date in the cookie is less than the date on the banner, the user dismissed an older banner *@

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <title>DDD East Anglia @ViewBag.Title</title>
-    <link href="http://www.dddeastanglia.com/favicon.ico")" rel="shortcut icon" type="image/x-icon" />
+    <link href="http://www.dddeastanglia.com/favicon.ico" rel="shortcut icon" type="image/x-icon" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="DDD East Anglia conference website 29 June 2013">
     <meta name="author" content="DDD East Anglia">
@@ -25,6 +25,7 @@
     <link rel="image_src" href="@Url.Content("~/Images/logo-small.png")" /> @*this apparently works with embed.ly for Twitter Cards*@
 </head>
     <body>
+        @Html.Partial("_Banner")
         <div class="container-fluid">
             <div class="row-fluid">
                 <div class="masthead">
@@ -140,7 +141,16 @@
         @Scripts.Render("~/bundles/bootstrap")
         @Styles.Render("~/Content/Markdown")
         @RenderSection("scripts", required: false)
-
+        
+        <script language="javascript">
+            $(document).ready(function() {
+                $("#notifications-banner").slideDown("slow");
+                $(".dismiss").click(function() {
+                    $("#notifications-banner").fadeOut("slow");
+                });
+            });
+        </script>     
+});
         @{Html.RenderPartial(MVC.Shared.Views._GoogleAnalytics);}
     </body>
 </html>

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -146,7 +146,7 @@
             $(document).ready(function() {
                 $("#notifications-banner").slideDown("slow");
                 $(".dismiss").click(function() {
-                    $("#notifications-banner").fadeOut("slow");
+                    $("#notifications-banner").slideUp("fast");
                 });
             });
         </script>     

--- a/DDDEastAnglia/Views/Speaker/Index.cshtml
+++ b/DDDEastAnglia/Views/Speaker/Index.cshtml
@@ -5,11 +5,6 @@
     ViewBag.Title = "Speakers";
 }
 
-@section featured
-{
-    @Html.Partial("_Banner")
-}
-
 <h2>Speakers</h2>
 
 @foreach (var speaker in Model)

--- a/DDDEastAnglia/packages.config
+++ b/DDDEastAnglia/packages.config
@@ -14,6 +14,7 @@
   <package id="Glimpse.AspNet" version="1.1.0" targetFramework="net40" />
   <package id="Glimpse.Mvc3" version="1.1.0" targetFramework="net40" />
   <package id="jQuery" version="1.9.1" targetFramework="net40" />
+  <package id="jquery.cookie" version="1.3.1" targetFramework="net40" />
   <package id="jQuery.UI.Combined" version="1.10.2" targetFramework="net40" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net40" />
   <package id="knockoutjs" version="2.1.0" targetFramework="net40" />


### PR DESCRIPTION
The box now appears at the top of the page (like to old Stack Overflow notifications bar did). You can dismiss it and it will stay away, but only up until the next promoted event starts where it will reappear.
