### PR TITLE
Add a speaker details page and link to it from the sessions

### DIFF
--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -208,11 +208,7 @@ fieldset {
     display: none;
 }
 
-.actions {
-    float: right;    
-}
-
-.actions .action {
+.action {
     padding-right: 10px;
 }
 

--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -176,7 +176,7 @@ fieldset {
     margin-bottom: 15px;
 }
 
-.session-details-own {
+.session-details-own, .speaker-own {
     border: 1px solid #e3e3e3;
     border-radius: 5px;
     background-color: #f5f5f5;
@@ -261,4 +261,5 @@ a i {
 
 .speaker {
     border-bottom: 1px solid lightgray;
+    padding: 10px;
 }

--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -208,11 +208,11 @@ fieldset {
     display: none;
 }
 
-.session-actions {
-    text-align: right;    
+.actions {
+    float: right;    
 }
 
-.session-actions .action {
+.actions .action {
     padding-right: 10px;
 }
 

--- a/DDDEastAnglia/Controllers/SessionController.cs
+++ b/DDDEastAnglia/Controllers/SessionController.cs
@@ -156,6 +156,7 @@ namespace DDDEastAnglia.Controllers
                     SessionId = session.SessionId,
                     SessionTitle = session.Title,
                     SessionAbstract = session.Abstract,
+                    SpeakerId = profile.UserId,
                     SpeakerName = profile.Name,
                     SpeakerUserName = session.SpeakerUserName,
                     SpeakerGravitarUrl = profile.GravitarUrl(),

--- a/DDDEastAnglia/Controllers/SpeakerController.cs
+++ b/DDDEastAnglia/Controllers/SpeakerController.cs
@@ -43,5 +43,32 @@ namespace DDDEastAnglia.Controllers
 
             return View(speakers);
         }
+
+        public virtual ActionResult Details(int id = 0)
+        {
+            var userProfile = db.UserProfiles.Find(id);
+        
+            if (userProfile == null)
+            {
+                return HttpNotFound();
+            }
+
+            var sessions = db.Sessions.Where(s => s.SpeakerUserName == userProfile.UserName);
+            var displayModel = CreateDisplayModel(userProfile, sessions);
+            return View(displayModel);
+        }
+
+        private SpeakerDisplayModel CreateDisplayModel(UserProfile userProfile, IEnumerable<Session> sessions)
+        {
+            return new SpeakerDisplayModel
+                {
+                    Name = userProfile.Name,
+                    GravatarUrl = userProfile.GravitarUrl(),
+                    Bio = userProfile.Bio,
+                    TwitterHandle = userProfile.TwitterHandle,
+                    WebsiteUrl = userProfile.WebsiteUrl,
+                    Sessions = sessions.ToDictionary(s => s.SessionId, s => s.Title)
+                };
+        }
     }
 }

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -466,6 +466,8 @@
     <Content Include="Views\Profile\Edit.cshtml" />
     <Content Include="Views\Session\_SessionDetailsPartial.cshtml" />
     <Content Include="Views\Shared\_Banner.cshtml" />
+    <Content Include="Views\Speaker\Details.cshtml" />
+    <Content Include="Views\Speaker\_SpeakerDetailsPartial.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/DDDEastAnglia/Models/SessionDisplayModel.cs
+++ b/DDDEastAnglia/Models/SessionDisplayModel.cs
@@ -5,9 +5,12 @@
         public int SessionId { get; set; }
         public string SessionTitle { get; set; }
         public string SessionAbstract { get; set; }
+        
+        public int SpeakerId { get; set; }
         public string SpeakerName { get; set; }
         public string SpeakerUserName { get; set; }
         public string SpeakerGravitarUrl { get; set; }
+        
         public SessionTweetLink TweetLink { get; set; }
         public bool IsUsersSession { get; set; }
     }

--- a/DDDEastAnglia/Models/SpeakerDisplayModel.cs
+++ b/DDDEastAnglia/Models/SpeakerDisplayModel.cs
@@ -9,6 +9,7 @@ namespace DDDEastAnglia.Models
             Sessions = new Dictionary<int, string>();
         }
 
+        public bool IsCurrentUser { get; set; }
         public string Name { get; set; }
         public string Bio { get; set; }
         public string TwitterHandle { get; set; }

--- a/DDDEastAnglia/SpeakerController.generated.cs
+++ b/DDDEastAnglia/SpeakerController.generated.cs
@@ -61,15 +61,25 @@ namespace DDDEastAnglia.Controllers
         public class ActionNamesClass
         {
             public readonly string Index = "Index";
+            public readonly string Details = "Details";
         }
 
         [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
         public class ActionNameConstants
         {
             public const string Index = "Index";
+            public const string Details = "Details";
         }
 
 
+        static readonly ActionParamsClass_Details s_params_Details = new ActionParamsClass_Details();
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public ActionParamsClass_Details DetailsParams { get { return s_params_Details; } }
+        [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
+        public class ActionParamsClass_Details
+        {
+            public readonly string id = "id";
+        }
         static readonly ViewsClass s_views = new ViewsClass();
         [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
         public ViewsClass Views { get { return s_views; } }
@@ -80,8 +90,12 @@ namespace DDDEastAnglia.Controllers
             public _ViewNamesClass ViewNames { get { return s_ViewNames; } }
             public class _ViewNamesClass
             {
+                public readonly string _SpeakerDetailsPartial = "_SpeakerDetailsPartial";
+                public readonly string Details = "Details";
                 public readonly string Index = "Index";
             }
+            public readonly string _SpeakerDetailsPartial = "~/Views/Speaker/_SpeakerDetailsPartial.cshtml";
+            public readonly string Details = "~/Views/Speaker/Details.cshtml";
             public readonly string Index = "~/Views/Speaker/Index.cshtml";
         }
     }
@@ -97,6 +111,16 @@ namespace DDDEastAnglia.Controllers
         {
             var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.Index);
             IndexOverride(callInfo);
+            return callInfo;
+        }
+
+        partial void DetailsOverride(T4MVC_System_Web_Mvc_ActionResult callInfo, int id);
+
+        public override System.Web.Mvc.ActionResult Details(int id)
+        {
+            var callInfo = new T4MVC_System_Web_Mvc_ActionResult(Area, Name, ActionNames.Details);
+            ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "id", id);
+            DetailsOverride(callInfo, id);
             return callInfo;
         }
 

--- a/DDDEastAnglia/Views/Session/Details.cshtml
+++ b/DDDEastAnglia/Views/Session/Details.cshtml
@@ -11,7 +11,7 @@
     {
         <img src="@Model.SpeakerGravitarUrl" alt="@Model.SpeakerName"  />
     }
-    @Html.DisplayFor(m => m.SpeakerName)
+    <a href="@Url.Action("Details", "Speaker", new { id = Model.SpeakerId })">@(string.IsNullOrWhiteSpace(Model.SpeakerName) ? Model.SpeakerUserName : Model.SpeakerName)</a>
 </div>
 
 <div class="tweet-session">

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -1,6 +1,17 @@
 ﻿@model DDDEastAnglia.Models.SessionDisplayModel
 
 <div class="session-details @(Model.IsUsersSession ? "session-details-own" : "")">
+    @if (Model.IsUsersSession)
+    {
+        <div class="actions">
+            <span class="action">
+                <i class="icon-edit"></i> @Html.ActionLink("Edit", MVC.Session.Edit(Model.SessionId))
+            </span>
+            <span class="action">
+                <i class="icon-trash"></i> @Html.ActionLink("Delete", MVC.Session.Delete(Model.SessionId))
+            </span>
+        </div>
+    }
     <h3>
         @Model.SessionTitle
     </h3>
@@ -14,15 +25,4 @@
     <div class="session-abstract">
         @Html.MarkdownFor(s => Model.SessionAbstract)
     </div>
-    @if (Model.IsUsersSession)
-    {
-        <div class="session-actions">
-            <span class="action">
-                <i class="icon-edit"></i> @Html.ActionLink("Edit", MVC.Session.Edit(Model.SessionId))
-            </span>
-            <span class="action">
-                <i class="icon-trash"></i> @Html.ActionLink("Delete", MVC.Session.Delete(Model.SessionId))
-            </span>
-        </div>
-    }
 </div>

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -3,7 +3,7 @@
 <div class="session-details @(Model.IsUsersSession ? "session-details-own" : "")">
     @if (Model.IsUsersSession)
     {
-        <div class="actions">
+        <div class="pull-right">
             <span class="action">
                 <i class="icon-edit"></i> @Html.ActionLink("Edit", MVC.Session.Edit(Model.SessionId))
             </span>

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -14,7 +14,7 @@
     <div class="session-abstract">
         @Html.MarkdownFor(s => Model.SessionAbstract)
     </div>
-    @if (Request.IsAuthenticated && User.Identity.Name == Model.SpeakerUserName)
+    @if (Model.IsUsersSession)
     {
         <div class="session-actions">
             <span class="action">

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -6,7 +6,7 @@
     </h3>
     <h4>
         <img src="@Model.SpeakerGravitarUrl" width="32" height="32" alt="@Model.SpeakerName">
-        @Model.SpeakerName
+        <a href="@Url.Action("Details", "Speaker", new { id = Model.SpeakerId })">@(string.IsNullOrWhiteSpace(Model.SpeakerName) ? Model.SpeakerUserName : Model.SpeakerName)</a>
     </h4>
     <div class="session-tweet">
         <a href="https://twitter.com/intent/tweet?text=@Model.TweetLink.Title" class="twitter-share-button" data-url="@Model.TweetLink.Url" data-count="none">Tweet</a>

--- a/DDDEastAnglia/Views/Speaker/Details.cshtml
+++ b/DDDEastAnglia/Views/Speaker/Details.cshtml
@@ -1,0 +1,7 @@
+﻿@model DDDEastAnglia.Models.SpeakerDisplayModel
+
+@{
+    ViewBag.Title = "Details";
+}
+
+@Html.Partial("_SpeakerDetailsPartial", Model)

--- a/DDDEastAnglia/Views/Speaker/Index.cshtml
+++ b/DDDEastAnglia/Views/Speaker/Index.cshtml
@@ -10,31 +10,6 @@
 @foreach (var speaker in Model)
 {
     <div class="row-fluid">
-        <div class="span12 speaker">
-            <h3><img src="@Html.Raw(speaker.GravatarUrl)" alt="@Html.Raw(speaker.Name)"/> @speaker.Name</h3>
-            <section class="links">
-                @if (!string.IsNullOrWhiteSpace(speaker.WebsiteUrl))
-                {
-                    <p><i class="icon-globe" style="color:green"></i> <a href="@speaker.WebsiteUrl">@speaker.WebsiteUrl</a></p>
-                }
-
-                @if (!string.IsNullOrWhiteSpace(speaker.TwitterHandle))
-                {
-                    <p><i class="icon-twitter" style="color:cornflowerblue"></i> <a href="http://twitter.com/@speaker.TwitterHandle">@("@" + speaker.TwitterHandle)</a></p>
-                }
-            </section>
-    
-            <p>@Html.MarkdownFor(m => speaker.Bio)</p>
-
-            <h4>Submitted Sessions</h4>
-            <ul>
-            @foreach (var session in speaker.Sessions)
-            {
-                <li><a href="@Url.Action(MVC.Session.Details(session.Key))" title="View the details for this session">@session.Value</a></li>
-            }
-            </ul>
-        </div>
+        @Html.Partial("_SpeakerDetailsPartial", speaker)
     </div>
 }
- 
-

--- a/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
@@ -2,6 +2,14 @@
 @model SpeakerDisplayModel
 
 <div class="span12 speaker @(Model.IsCurrentUser ? "speaker-own" : "")">
+    @if (Model.IsCurrentUser)
+    {
+        <div class="actions">
+            <span class="action">
+                <i class="icon-edit"></i> @Html.ActionLink("Edit Profile", "Edit", "Profile")
+            </span>
+        </div>
+    }
     <h3><img src="@Html.Raw(@Model.GravatarUrl)" alt="@Html.Raw(@Model.Name)"/> @Model.Name</h3>
     <section class="links">
         @if (!string.IsNullOrWhiteSpace(@Model.WebsiteUrl))

--- a/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
@@ -1,7 +1,7 @@
 ﻿@using DDDEastAnglia.Models
 @model SpeakerDisplayModel
 
-<div class="span12 speaker">
+<div class="span12 speaker @(Model.IsCurrentUser ? "speaker-own" : "")">
     <h3><img src="@Html.Raw(@Model.GravatarUrl)" alt="@Html.Raw(@Model.Name)"/> @Model.Name</h3>
     <section class="links">
         @if (!string.IsNullOrWhiteSpace(@Model.WebsiteUrl))

--- a/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
@@ -1,0 +1,27 @@
+﻿@using DDDEastAnglia.Models
+@model SpeakerDisplayModel
+
+<div class="span12 speaker">
+    <h3><img src="@Html.Raw(@Model.GravatarUrl)" alt="@Html.Raw(@Model.Name)"/> @Model.Name</h3>
+    <section class="links">
+        @if (!string.IsNullOrWhiteSpace(@Model.WebsiteUrl))
+        {
+            <p><i class="icon-globe" style="color:green"></i> <a href="@Model.WebsiteUrl">@Model.WebsiteUrl</a></p>
+        }
+
+        @if (!string.IsNullOrWhiteSpace(@Model.TwitterHandle))
+        {
+            <p><i class="icon-twitter" style="color:cornflowerblue"></i> <a href="http://twitter.com/@Model.TwitterHandle">@("@" + @Model.TwitterHandle)</a></p>
+        }
+    </section>
+    
+    <p>@Html.MarkdownFor(m => @Model.Bio)</p>
+
+    <h4>Submitted Sessions</h4>
+    <ul>
+    @foreach (var session in @Model.Sessions)
+    {
+        <li><a href="@Url.Action(MVC.Session.Details(session.Key))" title="View the details for this session">@session.Value</a></li>
+    }
+    </ul>
+</div>

--- a/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
@@ -4,7 +4,7 @@
 <div class="span12 speaker @(Model.IsCurrentUser ? "speaker-own" : "")">
     @if (Model.IsCurrentUser)
     {
-        <div class="actions">
+        <div class="pull-right">
             <span class="action">
                 <i class="icon-edit"></i> @Html.ActionLink("Edit Profile", "Edit", "Profile")
             </span>


### PR DESCRIPTION
This pull request adds a speaker page, so that the details of an individual speaker can be shown/linked to. This page is linked to from each session.

To do this, I've extracted a partial view for showing the speaker details, and refactored some code in the controllers.

I've also styled the speakers page to be consistent with the sessions page so that a user's own profile will be highlighted and have a link to edit it.
