### PR TITLE
Fix #42: Use HTML5 input types where possible

### DIFF
--- a/DDDEastAnglia/Views/Account/ChangePassword.cshtml
+++ b/DDDEastAnglia/Views/Account/ChangePassword.cshtml
@@ -25,24 +25,24 @@ else
             <div class="control-group">
                 @Html.LabelFor(m => m.OldPassword, new { @class = "control-label"})
                 <div class="controls">
-                @Html.PasswordFor(m => m.OldPassword)
-                @Html.ValidationMessageFor(m => m.OldPassword)
+                    @Html.PasswordFor(m => m.OldPassword)
+                    @Html.ValidationMessageFor(m => m.OldPassword)
                 </div>
             </div>
 
             <div class="control-group">
                 @Html.LabelFor(m => m.NewPassword, new { @class = "control-label"})
                 <div class="controls">
-                @Html.PasswordFor(m => m.NewPassword)
-                @Html.ValidationMessageFor(m => m.NewPassword)
+                    @Html.PasswordFor(m => m.NewPassword)
+                    @Html.ValidationMessageFor(m => m.NewPassword)
                 </div>
             </div>
 
             <div class="control-group">
                 @Html.LabelFor(m => m.ConfirmPassword, new { @class = "control-label"})
                 <div class="controls">
-                @Html.PasswordFor(m => m.ConfirmPassword)
-                @Html.ValidationMessageFor(m => m.ConfirmPassword)
+                    @Html.PasswordFor(m => m.ConfirmPassword)
+                    @Html.ValidationMessageFor(m => m.ConfirmPassword)
                 </div>
             </div>
         

--- a/DDDEastAnglia/Views/Account/ExternalLoginConfirmation.cshtml
+++ b/DDDEastAnglia/Views/Account/ExternalLoginConfirmation.cshtml
@@ -39,7 +39,7 @@
         <div class="control-group">
             @Html.LabelFor(m => m.EmailAddress, new { @class = "control-label"})
             <div class="controls">
-                @Html.TextBoxFor(m => m.EmailAddress)
+                @Html.TextBoxFor(m => m.EmailAddress, new { type = "email" })
                 @Html.ValidationMessageFor(m => m.EmailAddress)
             </div>
         </div>

--- a/DDDEastAnglia/Views/Account/Login.cshtml
+++ b/DDDEastAnglia/Views/Account/Login.cshtml
@@ -21,7 +21,7 @@
         @Html.ValidationSummary(true)
 
         <div class="control-group">
-            @Html.LabelFor(m => m.UserName, new { @class = "control-label"})
+            @Html.LabelFor(m => m.UserName, new { @class = "control-label", autofocus = true })
             <div class="controls">
                 @Html.TextBoxFor(m => m.UserName)
                 @Html.ValidationMessageFor(m => m.UserName)

--- a/DDDEastAnglia/Views/Account/Login.cshtml
+++ b/DDDEastAnglia/Views/Account/Login.cshtml
@@ -23,23 +23,23 @@
         <div class="control-group">
             @Html.LabelFor(m => m.UserName, new { @class = "control-label"})
             <div class="controls">
-            @Html.TextBoxFor(m => m.UserName)
-            @Html.ValidationMessageFor(m => m.UserName)
+                @Html.TextBoxFor(m => m.UserName)
+                @Html.ValidationMessageFor(m => m.UserName)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => m.Password, new { @class = "control-label"})
+            @Html.LabelFor(m => m.Password, new { @class = "control-label" })
             <div class="controls">
-            @Html.PasswordFor(m => m.Password)
-            @Html.ValidationMessageFor(m => m.Password)
+                @Html.PasswordFor(m => m.Password)
+                @Html.ValidationMessageFor(m => m.Password)
             </div>
         </div>
 
         <div class="control-group">
             <div class="controls">
-            @Html.CheckBoxFor(m => m.RememberMe)
-            @Html.LabelFor(m => m.RememberMe, new { @class = "checkbox inline" })
+                @Html.CheckBoxFor(m => m.RememberMe)
+                @Html.LabelFor(m => m.RememberMe, new { @class = "checkbox inline" })
             </div>
         
         </div>

--- a/DDDEastAnglia/Views/Account/Register.cshtml
+++ b/DDDEastAnglia/Views/Account/Register.cshtml
@@ -5,7 +5,7 @@
 
 <h2>Create a local account</h2>
 
-@using (Html.BeginForm("Register", "Account", FormMethod.Post, new { @class = "form-horizontal"})) 
+@using (Html.BeginForm("Register", "Account", FormMethod.Post, new { @class = "form-horizontal" })) 
 {
     @Html.AntiForgeryToken()
 
@@ -15,39 +15,39 @@
         @Html.ValidationSummary(true)
 
         <div class="control-group">
-            @Html.LabelFor(m => m.FullName, new { @class = "control-label"})
+            @Html.LabelFor(m => m.FullName, new { @class = "control-label" })
             <div class="controls">
-            @Html.TextBoxFor(m => m.FullName)
-            @Html.ValidationMessageFor(m => m.FullName)
+                @Html.TextBoxFor(m => m.FullName)
+                @Html.ValidationMessageFor(m => m.FullName)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => m.EmailAddress, new { @class = "control-label"})
+            @Html.LabelFor(m => m.EmailAddress, new { @class = "control-label" })
             <div class="controls">
-            @Html.TextBoxFor(m => m.EmailAddress)
-            @Html.ValidationMessageFor(m => m.EmailAddress)
+                @Html.TextBoxFor(m => m.EmailAddress)
+                @Html.ValidationMessageFor(m => m.EmailAddress)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => m.UserName, new { @class = "control-label"})
+            @Html.LabelFor(m => m.UserName, new { @class = "control-label" })
             <div class="controls">
-            @Html.TextBoxFor(m => m.UserName)
-            @Html.ValidationMessageFor(m => m.UserName)
+                @Html.TextBoxFor(m => m.UserName)
+                @Html.ValidationMessageFor(m => m.UserName)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => m.Password, new { @class = "control-label"})
+            @Html.LabelFor(m => m.Password, new { @class = "control-label" })
             <div class="controls">
-            @Html.PasswordFor(m => m.Password)
-            @Html.ValidationMessageFor(m => m.Password)
+                @Html.PasswordFor(m => m.Password)
+                @Html.ValidationMessageFor(m => m.Password)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => m.ConfirmPassword, new { @class = "control-label"})
+            @Html.LabelFor(m => m.ConfirmPassword, new { @class = "control-label" })
             <div class="controls">
                 @Html.PasswordFor(m => m.ConfirmPassword)
                 @Html.ValidationMessageFor(m => m.ConfirmPassword)

--- a/DDDEastAnglia/Views/Account/Register.cshtml
+++ b/DDDEastAnglia/Views/Account/Register.cshtml
@@ -17,7 +17,7 @@
         <div class="control-group">
             @Html.LabelFor(m => m.FullName, new { @class = "control-label" })
             <div class="controls">
-                @Html.TextBoxFor(m => m.FullName)
+                @Html.TextBoxFor(m => m.FullName, new { autofocus = true })
                 @Html.ValidationMessageFor(m => m.FullName)
             </div>
         </div>
@@ -25,7 +25,7 @@
         <div class="control-group">
             @Html.LabelFor(m => m.EmailAddress, new { @class = "control-label" })
             <div class="controls">
-                @Html.TextBoxFor(m => m.EmailAddress)
+                @Html.TextBoxFor(m => m.EmailAddress, new { type = "email" })
                 @Html.ValidationMessageFor(m => m.EmailAddress)
             </div>
         </div>

--- a/DDDEastAnglia/Views/Profile/Edit.cshtml
+++ b/DDDEastAnglia/Views/Profile/Edit.cshtml
@@ -12,7 +12,7 @@
 }
 
 <section id="profile">
-@using (Html.BeginForm("UserProfile", "Profile", FormMethod.Post, new { @class = "form-horizontal"}))
+@using (Html.BeginForm("UserProfile", "Profile", FormMethod.Post, new { @class = "form-horizontal" }))
 {
     <fieldset>
         <legend>Please provide as much information as possible</legend>
@@ -22,7 +22,7 @@
         @Html.HiddenFor(m => m.UserName)
         
         <div class="control-group">
-            @Html.LabelFor(m => Model.Name, new { @class = "control-label"})
+            @Html.LabelFor(m => Model.Name, new { @class = "control-label" })
             <div class="controls">
                 @Html.TextBoxFor(m => Model.Name)
                 @Html.ValidationMessageFor(m => Model.Name)
@@ -30,7 +30,7 @@
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => Model.EmailAddress, new { @class = "control-label"})
+            @Html.LabelFor(m => Model.EmailAddress, new { @class = "control-label" })
             <div class="controls">
                 @Html.TextBoxFor(m => Model.EmailAddress)
                 @Html.ValidationMessageFor(m => Model.EmailAddress)
@@ -38,14 +38,14 @@
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => Model.MobilePhone, new { @class = "control-label"})
+            @Html.LabelFor(m => Model.MobilePhone, new { @class = "control-label" })
             <div class="controls">
                 @Html.TextBoxFor(m => Model.MobilePhone)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => Model.TwitterHandle, new { @class = "control-label"})
+            @Html.LabelFor(m => Model.TwitterHandle, new { @class = "control-label" })
             <div class="controls">
                 <div class="input-prepend">
                     <span class="add-on">@@</span>
@@ -55,14 +55,14 @@
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => Model.WebsiteUrl, new { @class = "control-label"})
+            @Html.LabelFor(m => Model.WebsiteUrl, new { @class = "control-label" })
             <div class="controls">
                 @Html.TextBoxFor(m => Model.WebsiteUrl)
             </div>
         </div>
 
         <div class="control-group">
-            @Html.LabelFor(m => Model.Bio, new { @class = "control-label"})
+            @Html.LabelFor(m => Model.Bio, new { @class = "control-label" })
             <div class="controls">
                 <div id="wmd-button-bar"></div>
                 <div>

--- a/DDDEastAnglia/Views/Profile/Edit.cshtml
+++ b/DDDEastAnglia/Views/Profile/Edit.cshtml
@@ -24,7 +24,7 @@
         <div class="control-group">
             @Html.LabelFor(m => Model.Name, new { @class = "control-label" })
             <div class="controls">
-                @Html.TextBoxFor(m => Model.Name)
+                @Html.TextBoxFor(m => Model.Name, new { autofocus = true })
                 @Html.ValidationMessageFor(m => Model.Name)
             </div>
         </div>
@@ -32,7 +32,7 @@
         <div class="control-group">
             @Html.LabelFor(m => Model.EmailAddress, new { @class = "control-label" })
             <div class="controls">
-                @Html.TextBoxFor(m => Model.EmailAddress)
+                @Html.TextBoxFor(m => Model.EmailAddress, new { type = "email" })
                 @Html.ValidationMessageFor(m => Model.EmailAddress)
             </div>
         </div>
@@ -40,7 +40,7 @@
         <div class="control-group">
             @Html.LabelFor(m => Model.MobilePhone, new { @class = "control-label" })
             <div class="controls">
-                @Html.TextBoxFor(m => Model.MobilePhone)
+                @Html.TextBoxFor(m => Model.MobilePhone, new { type = "tel" })
             </div>
         </div>
 
@@ -57,7 +57,7 @@
         <div class="control-group">
             @Html.LabelFor(m => Model.WebsiteUrl, new { @class = "control-label" })
             <div class="controls">
-                @Html.TextBoxFor(m => Model.WebsiteUrl)
+                @Html.TextBoxFor(m => Model.WebsiteUrl, new { type = "url" })
             </div>
         </div>
 

--- a/DDDEastAnglia/Views/Shared/_LoginPartial.cshtml
+++ b/DDDEastAnglia/Views/Shared/_LoginPartial.cshtml
@@ -1,4 +1,5 @@
-﻿@if (Request.IsAuthenticated) {
+﻿@if (Request.IsAuthenticated)
+{
     <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
         <i class="icon-user"></i> @User.Identity.Name
         <span class="caret"></span>
@@ -49,7 +50,6 @@ else
         <li>
             <a href="@Url.Action(MVC.Account.Login())"><i class="icon-user"></i> Log in with DDDEA account</a>
         </li>
-        @*<li><a data-toggle="modal" href="#openIdLogin">Log in with an OpenID</a></li>*@
         <li class="divider"></li>
         <li>@Html.ActionLink("Register", "Register", "Account", null, new { id = "registerLink" })</li>
     </ul>


### PR DESCRIPTION
Turns out there weren't many places where this could be done, but it's useful for those fields that are of a particular type (e.g., email, URL, etc.). The fields are now auto-validated by the browser, and jQuery validation hooks into the validation API of the browser so error messages are displayed consistently.
