### PR TITLE
Fix #53: The tweet links are (sometimes) including the session url twice.

### DIFF
--- a/DDDEastAnglia/App_Code/HTMLExtensions.cs
+++ b/DDDEastAnglia/App_Code/HTMLExtensions.cs
@@ -52,4 +52,20 @@ public static class HTMLExtensions
         }
         return "";
     }
+
+    public static MvcHtmlString TweetButton(this HtmlHelper htmlHelper, string tweetText, Uri url = null)
+    {
+        var encodedTweetText = Uri.EscapeDataString(tweetText); // escape anything URI-unfriendly in the tweet body (e.g., hash-tags)
+        
+        if (url != null)
+        {
+            encodedTweetText += " " + Uri.EscapeUriString(url.ToString()); // escape the URL
+        }
+
+        encodedTweetText = htmlHelper.Encode(encodedTweetText); // HTML-encode the resulting string
+        return new MvcHtmlString(
+            string.Format(
+                @"<a href=""https://twitter.com/intent/tweet?text={0}"" class=""btn btn-mini""><i class=""icon-twitter""></i> Tweet</a>",
+                encodedTweetText));
+    }
 }

--- a/DDDEastAnglia/App_Start/BundleConfig.cs
+++ b/DDDEastAnglia/App_Start/BundleConfig.cs
@@ -58,9 +58,6 @@ namespace DDDEastAnglia
 
             AddStyleBundle(bundles, "~/Content/Markdown",
                            "~/Content/Markdown.css");
-
-            AddStyleBundle(bundles, "~/bundles/tweetbutton",
-                           "~/Scripts/tweetbutton.js");
         }
 
         private static void AddScriptBundle(BundleCollection bundles, string virtualPath, params string[] scriptFiles)

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -253,7 +253,6 @@
     <Content Include="Scripts\jquery.cookie.js" />
     <Content Include="Scripts\jquery.tablesorter.js" />
     <Content Include="Scripts\jquery.tablesorter.min.js" />
-    <Content Include="Scripts\tweetbutton.js" />
     <Compile Include="ProfileController.generated.cs">
       <DependentUpon>T4MVC.tt</DependentUpon>
     </Compile>

--- a/DDDEastAnglia/Scripts/tweetbutton.js
+++ b/DDDEastAnglia/Scripts/tweetbutton.js
@@ -1,1 +1,0 @@
-﻿!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = "//platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");

--- a/DDDEastAnglia/Views/Session/Details.cshtml
+++ b/DDDEastAnglia/Views/Session/Details.cshtml
@@ -17,13 +17,13 @@
 <div class="tweet-session">
     @if (User.Identity.Name == Model.SpeakerUserName)
     {
-        <a href="https://twitter.com/intent/tweet?text=@Html.Encode("Check out my session for #dddea -") @Model.SessionTitle @Request.Url" class="twitter-share-button" data-url="@Request.Url" data-count="none">Tweet</a>
+        @Html.TweetButton("Check out my session for #dddea - " + Model.SessionTitle, Request.Url)
     }
     else
-    { 
-        <a href="https://twitter.com/intent/tweet?text=@Html.Encode("Check out this session for #dddea -") @Model.SessionTitle @Request.Url" class="twitter-share-button" data-url="@Request.Url" data-count="none">Tweet</a>
+    {
+        @Html.TweetButton("Check out this session for #dddea - " + Model.SessionTitle, Request.Url)
     }
-    <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = "//platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
+
 </div>
 
 <div class="abstract">

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -20,7 +20,7 @@
         <a href="@Url.Action("Details", "Speaker", new { id = Model.SpeakerId })">@(string.IsNullOrWhiteSpace(Model.SpeakerName) ? Model.SpeakerUserName : Model.SpeakerName)</a>
     </h4>
     <div class="session-tweet">
-        <a href="https://twitter.com/intent/tweet?text=@Model.TweetLink.Title" class="twitter-share-button" data-url="@Model.TweetLink.Url" data-count="none">Tweet</a>
+        @Html.TweetButton(Model.TweetLink.Title)
     </div>
     <div class="session-abstract">
         @Html.MarkdownFor(s => Model.SessionAbstract)

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -10,7 +10,6 @@
     @Styles.Render("~/Content/css")
     @Scripts.Render("~/bundles/Markdown")
     @Scripts.Render("~/bundles/modernizr")
-    @Scripts.Render("~/bundles/tweetbutton")
     @RenderSection("header", false)
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->


### PR DESCRIPTION
Introduced a new HTML Helper for the Tweet button (see 3aec308 for documentation of the escaping and encoding needed). Removed, thoroughly, the old Tweet button.
