### PR TITLE
EntityFramework keeping cached state for voting

### DIFF
--- a/DDDEastAnglia/DataAccess/EntityFramework/EntityFrameworkConferenceRepository.cs
+++ b/DDDEastAnglia/DataAccess/EntityFramework/EntityFrameworkConferenceRepository.cs
@@ -7,7 +7,6 @@ namespace DDDEastAnglia.DataAccess.EntityFramework
     public class EntityFrameworkConferenceRepository : IConferenceRepository
     {
         private readonly IBuild<Models.Conference, Conference> _conferenceBuilder;
-        private readonly DDDEAContext _context = new DDDEAContext();
 
         public EntityFrameworkConferenceRepository(IBuild<Models.Conference, Conference> conferenceBuilder)
         {
@@ -16,24 +15,33 @@ namespace DDDEastAnglia.DataAccess.EntityFramework
 
         public Conference ForSession(int sessionId)
         {
-            var session = _context.Sessions.Find(sessionId);
-            return Get(session.ConferenceId);
+            using (var dddeaContext = new DDDEAContext())
+            {
+                var session = dddeaContext.Sessions.Find(sessionId);
+                return Get(session.ConferenceId);
+            }
         }
 
         public Conference GetByEventShortName(string shortName)
         {
-            var currentConference = _context.Conferences
-                                            .Include("CalendarItems")
-                                            .SingleOrDefault(conf => conf.ShortName == shortName);
-            return _conferenceBuilder.Build(currentConference);
+            using (var dddeaContext = new DDDEAContext())
+            {
+                var currentConference = dddeaContext.Conferences
+                                                    .Include("CalendarItems")
+                                                    .SingleOrDefault(conf => conf.ShortName == shortName);
+                return _conferenceBuilder.Build(currentConference);
+            }
         }
 
         private Conference Get(int conferenceId)
         {
-            var currentConference = _context.Conferences
-                                            .Include("CalendarItems")
-                                            .SingleOrDefault(conf => conf.ConferenceId == conferenceId);
-            return _conferenceBuilder.Build(currentConference);
+            using (var dddeaContext = new DDDEAContext())
+            {
+                var currentConference = dddeaContext.Conferences
+                                                .Include("CalendarItems")
+                                                .SingleOrDefault(conf => conf.ConferenceId == conferenceId);
+                return _conferenceBuilder.Build(currentConference);
+            }
         }
     }
 }

--- a/DDDEastAnglia/DataAccess/EntityFramework/EntityFrameworkSessionRepository.cs
+++ b/DDDEastAnglia/DataAccess/EntityFramework/EntityFrameworkSessionRepository.cs
@@ -4,16 +4,21 @@ namespace DDDEastAnglia.DataAccess.EntityFramework
 {
     public class EntityFrameworkSessionRepository : ISessionRepository
     {
-        private readonly DDDEAContext context = new DDDEAContext();
 
         public Session Get(int id)
         {
-            return context.Sessions.Find(id);
+            using (var dddeaContext = new DDDEAContext())
+            {
+                return dddeaContext.Sessions.Find(id);
+            }
         }
 
         public bool Exists(int id)
         {
-            return context.Sessions.Find(id) != null;
+            using (var dddeaContext = new DDDEAContext())
+            {
+                return dddeaContext.Sessions.Find(id) != null;
+            }
         }
     }
 }

--- a/DDDEastAnglia/DataAccess/EntityFramework/EntityFrameworkVoteRepository.cs
+++ b/DDDEastAnglia/DataAccess/EntityFramework/EntityFrameworkVoteRepository.cs
@@ -6,28 +6,36 @@ namespace DDDEastAnglia.DataAccess.EntityFramework
 {
     public class EntityFrameworkVoteRepository : IVoteRepository
     {
-        private readonly DDDEAContext _context = new DDDEAContext();
-
         public void Save(Vote vote)
         {
-            _context.Votes.Add(vote);
-            _context.SaveChanges();
+            using (var dddeaContext = new DDDEAContext())
+            {
+                dddeaContext.Votes.Add(vote);
+                dddeaContext.SaveChanges();
+            }
         }
 
         public void Delete(int sessionId, Guid cookieId)
         {
-            var toDelete = _context.Votes.FirstOrDefault(vote => vote.SessionId == sessionId && vote.CookieId == cookieId);
-            if (toDelete == null)
+            using (var dddeaContext = new DDDEAContext())
             {
-                return;
+                var toDelete =
+                    dddeaContext.Votes.FirstOrDefault(vote => vote.SessionId == sessionId && vote.CookieId == cookieId);
+                if (toDelete == null)
+                {
+                    return;
+                }
+                dddeaContext.Votes.Remove(toDelete);
+                dddeaContext.SaveChanges();
             }
-            _context.Votes.Remove(toDelete);
-            _context.SaveChanges();
         }
 
         public bool HasVotedFor(int sessionId, Guid cookieId)
         {
-            return _context.Votes.Any(vote => vote.CookieId == cookieId && vote.SessionId == sessionId);
+            using (var dddeaContext = new DDDEAContext())
+            {
+                return dddeaContext.Votes.Any(vote => vote.CookieId == cookieId && vote.SessionId == sessionId);
+            }
         }
     }
 }

--- a/DDDEastAnglia/DataAccess/EntityFramework/Queries/EntityFrameworkBannerModelQuery.cs
+++ b/DDDEastAnglia/DataAccess/EntityFramework/Queries/EntityFrameworkBannerModelQuery.cs
@@ -11,7 +11,6 @@ namespace DDDEastAnglia.DataAccess.EntityFramework.Queries
     public class EntityFrameworkBannerModelQuery : IBannerModelQuery
     {
         private readonly IBuild<Conference, Domain.Conference> _conferenceBuilder;
-        private readonly DDDEAContext _context = new DDDEAContext();
 
         public EntityFrameworkBannerModelQuery(IBuild<Conference, Domain.Conference> conferenceBuilder)
         {
@@ -21,45 +20,48 @@ namespace DDDEastAnglia.DataAccess.EntityFramework.Queries
 
         public BannerModel Get(string conferenceShortName)
         {
-            var conference =
-                _context.Conferences.Include("CalendarItems")
-                        .SingleOrDefault(item => item.ShortName == conferenceShortName);
-            if (conference == null)
+            using (var dddeaContext = new DDDEAContext())
             {
-                return new BannerModel();
-            }
-            var domainConference = _conferenceBuilder.Build(conference);
-            if (domainConference == null)
-            {
-                return new BannerModel();
-            }
-            DateTimeOffset submissionCloses = DateTimeOffset.Now.AddDays(-1);
-            DateTimeOffset votingCloses = DateTimeOffset.Now.AddDays(-1);
-            if (conference.CalendarItems != null)
-            {
-                var submission =
-                    conference.CalendarItems.SingleOrDefault(
-                        item => item.EntryType == CalendarEntryType.SessionSubmission);
-                if (submission != null && submission.EndDate.HasValue)
+                var conference =
+                    dddeaContext.Conferences.Include("CalendarItems")
+                            .SingleOrDefault(item => item.ShortName == conferenceShortName);
+                if (conference == null)
                 {
-                    submissionCloses = submission.EndDate.Value;
+                    return new BannerModel();
                 }
-                var voting =
-                    conference.CalendarItems.SingleOrDefault(
-                        item => item.EntryType == CalendarEntryType.Voting);
-                if (voting != null && voting.EndDate.HasValue)
+                var domainConference = _conferenceBuilder.Build(conference);
+                if (domainConference == null)
                 {
-                    votingCloses = voting.EndDate.Value;
+                    return new BannerModel();
                 }
-            }
+                DateTimeOffset submissionCloses = DateTimeOffset.Now.AddDays(-1);
+                DateTimeOffset votingCloses = DateTimeOffset.Now.AddDays(-1);
+                if (conference.CalendarItems != null)
+                {
+                    var submission =
+                        conference.CalendarItems.SingleOrDefault(
+                            item => item.EntryType == CalendarEntryType.SessionSubmission);
+                    if (submission != null && submission.EndDate.HasValue)
+                    {
+                        submissionCloses = submission.EndDate.Value;
+                    }
+                    var voting =
+                        conference.CalendarItems.SingleOrDefault(
+                            item => item.EntryType == CalendarEntryType.Voting);
+                    if (voting != null && voting.EndDate.HasValue)
+                    {
+                        votingCloses = voting.EndDate.Value;
+                    }
+                }
 
-            return new BannerModel
-                {
-                    IsOpenForSubmission = domainConference.CanSubmit(),
-                    IsOpenForVoting = domainConference.CanVote(),
-                    SessionSubmissionCloses = submissionCloses.ToString("R"),
-                    VotingCloses = votingCloses.ToString("R")
-                };
+                return new BannerModel
+                    {
+                        IsOpenForSubmission = domainConference.CanSubmit(),
+                        IsOpenForVoting = domainConference.CanVote(),
+                        SessionSubmissionCloses = submissionCloses.ToString("R"),
+                        VotingCloses = votingCloses.ToString("R")
+                    };
+            }
         }
     }
 }


### PR DESCRIPTION
This will, for the moment, fix the issue with the EntityFramework caching state preventing any underlying database changes (e.g. changing the StartDate for CalendarItems by directly going to the database)

Going forward I think we will want to find a more elegant solution, along the lines of UnitOfWork but I just want to get this change in and work on that separately
