### PR TITLE
Fix #106: Use h2 for page title on New to DDD page

### DIFF
--- a/DDDEastAnglia/Views/Home/About.cshtml
+++ b/DDDEastAnglia/Views/Home/About.cshtml
@@ -12,7 +12,7 @@
     
     <div class="span12">
         <div class="page-header">
-            <h1>About DDD East Anglia</h1>
+            <h2>About DDD East Anglia</h2>
         </div>
 
         <p>
@@ -39,7 +39,7 @@
             allowed!
         </p>
 
-        <h2 id="ddd-process">How is the agenda decided?</h2>
+        <h3 id="ddd-process">How is the agenda decided?</h3>
         <p>
             DDD events are unique in that <strong>the conference is made by its attendees</strong>. <a href="#sessions">Sessions</a> are submitted by members of the
             UK .NET developer community (i.e. <em>you</em> can @Html.ActionLink("submit a session", "Create", "Session")), and are voted on by prospective attendees
@@ -51,26 +51,26 @@
             speakers from a more remote geographical location.
         </p>
 
-        <h2 id="sessions">Session Submission FAQs</h2>
-        <h3 id="submissions-open">When do submissions open?</h3>
+        <h3 id="sessions">Session Submission FAQs</h3>
+        <h4 id="submissions-open">When do submissions open?</h4>
         <p>
             Session submissions usually opens a couple of months in advance of the DDD event. This allows us time to collate all the submissions,
             vote on the submissions, and create an agenda for the day from the results of the voting process.
         </p>
 
-        <h3 id="session-length">How long should my session be?</h3>
+        <h4 id="session-length">How long should my session be?</h4>
         <p>
             Sessions at DDD events last for one hour.
         </p>
 
-        <h3 id="session-topics">What topics do you accept sessions on?</h3>
+        <h4 id="session-topics">What topics do you accept sessions on?</h4>
         <p>
             Anything relevant to a .NET developer! Other DDD events have seen submissions on the Raspberry Pi and Gadgeteer, Unit Testing and Test-Driven Development, NoSQL
             databases like RavenDB and Redis, JavaScript, mobile devices. &quot;Softer&quot; topics such as best practices, agile software development, and taking your side
             project to a prime time business, have also been presented.
         </p>
         
-        <h3 id="session-format">What format do sessions at DDD events take?</h3>
+        <h4 id="session-format">What format do sessions at DDD events take?</h4>
         <p>
             DDD sessions are usually single-speaker talks on a specific subject, although some have featured multiple speakers. Technical sessions, particularly those
             featuring hardware elements (e.g. Raspberry Pi), work well when demos and code samples are included. That said, we also welcome sessions that are based around a
@@ -81,7 +81,7 @@
             the event organisers rather than through submissions.
         </p>
         
-        <h3 id="session-expertise">Do I need to be an expert in my topic?</h3>
+        <h4 id="session-expertise">Do I need to be an expert in my topic?</h4>
         <p>
             <strong>No.</strong> One of the aims of DDD events is to grow the local speaker community, which means favouring new speakers as well as local speakers. DDD
             audiences are interested in hearing about what you've learned about the topic that you are speaking on; being introduced to a new topic, idea, or technology;


### PR DESCRIPTION
Also bump all the other headings on the page down a level for consistency.
