### PR TITLE
Fix #104: Make the build run the tests

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.Runners" version="2.6.2" />
+</packages>

--- a/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
+++ b/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DDDEastAnglia.Tests</RootNamespace>
     <AssemblyName>DDDEastAnglia.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DDDEastAnglia.sln
+++ b/DDDEastAnglia.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{9D1C6E
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
+		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DDDEastAnglia.Tests", "DDDEastAnglia.Tests\DDDEastAnglia.Tests.csproj", "{C7556082-8C2F-4ECA-A7FF-E54AEEBBDD28}"

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -11,6 +11,7 @@ Task default -Depends Test
 
 Task Test -Depends Compile {
     $nunitDir = Join-Path ((ls "${root}\packages\*" -Filter NUnit.Runners*) | select -last 1) "tools"
+    Write-Host "NUnit Console Runner found at $nunitDir"
     $env:Path = $nunitDir + ";" + $env:Path
 
     $testAssemblies = @(ls -Recurse "${root}\DDDEastAnglia*\bin" -Filter "DDDEastAnglia*Tests.dll")

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -5,6 +5,8 @@ properties {
 Include .\teamcity.ps1
 TaskSetup {
     TeamCity-ReportBuildProgress "Running task '$($psake.context.Peek().currentTaskName)'"
+
+    Format-Table -InputObject $properties
 }
 
 Task default -Depends Test

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -7,11 +7,24 @@ TaskSetup {
     TeamCity-ReportBuildProgress "Running task '$($psake.context.Peek().currentTaskName)'"
 }
 
-Task default -Depends Compile
+Task default -Depends Test
+
+Task Test -Depends Compile {
+    $nunitDir = Join-Path ((ls "${root}\packages\*" -Filter NUnit.Runners*) | select -last 1) "tools"
+    $env:Path = $nunitDir + ";" + $env:Path
+
+    $testAssemblies = ls -Recurse "${root}\DDDEastAnglia*\bin" -Filter "DDDEastAnglia*Tests.dll"
+
+    Write-Host "Running tests" -ForegroundColor Green
+    Exec { nunit-console $testAssemblies /framework="4.0" /nologo /nodots /result="${root}\TestResult.xml" /process="Separate" }
+}
 
 Task Compile -Depends Clean {
+    Write-Host "Restoring Solution-level NuGet packages" -ForegroundColor Green	
+    Exec { nuget install "${root}\.nuget\packages.config" -OutputDirectory "${root}\packages" }
+
     Write-Host "Building DDDEastAnglia.sln" -ForegroundColor Green
-	Exec { msbuild "${root}\DDDEastAnglia.sln" /t:Build /p:Configuration=Release /m }
+    Exec { msbuild "${root}\DDDEastAnglia.sln" /t:Build /p:Configuration=Release /m }
 }
 
 Task Clean {

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -13,7 +13,8 @@ Task Test -Depends Compile {
     $nunitDir = Join-Path ((ls "${root}\packages\*" -Filter NUnit.Runners*) | select -last 1) "tools"
     $env:Path = $nunitDir + ";" + $env:Path
 
-    $testAssemblies = ls -Recurse "${root}\DDDEastAnglia*\bin" -Filter "DDDEastAnglia*Tests.dll"
+    $testAssemblies = @(ls -Recurse "${root}\DDDEastAnglia*\bin" -Filter "DDDEastAnglia*Tests.dll")
+    Write-Host ("Found {0} test assemblies: {1}" -f $testAssemblies.Length, ($testAssemblies -join ", "))
 
     Write-Host "Running tests" -ForegroundColor Green
     Exec { nunit-console $testAssemblies /framework="4.0" /nologo /nodots /result="${root}\TestResult.xml" /process="Separate" }

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -16,7 +16,7 @@ Task Test -Depends Compile {
     Write-Host "NUnit Console Runner found at $nunitDir"
     $env:Path = $nunitDir + ";" + $env:Path
 
-    $testAssemblies = @(ls -Recurse "${root}\DDDEastAnglia*\bin" -Filter "DDDEastAnglia*Tests.dll")
+    $testAssemblies = @(ls -Recurse "${root}\DDDEastAnglia*\bin" -Include "DDDEastAnglia*Tests.dll")
     Write-Host ("Found {0} test assemblies: {1}" -f $testAssemblies.Length, ($testAssemblies -join ", "))
 
     Write-Host "Running tests" -ForegroundColor Green

--- a/build/environment.ps1
+++ b/build/environment.ps1
@@ -1,0 +1,7 @@
+param([Parameter(Mandatory=$true)][string]$rootDir)
+
+$additionalPaths = @(
+    Join-Path $rootDir ".nuget"
+)
+
+$env:path = ($additionalPaths -join ";") + ";$env:path"

--- a/build/run-build.ps1
+++ b/build/run-build.ps1
@@ -1,3 +1,6 @@
 $rootDir = join-path (Split-Path $MyInvocation.MyCommand.Path) ".."
+
+& "${rootDir}\build\environment.ps1" $rootDir
+
 Import-Module (join-path $rootDir "psake\psake.psm1")
 invoke-psake -framework '4.0' (join-path $rootDir "build\build.ps1") -properties @{"root"="$rootDir";}


### PR DESCRIPTION
:alarm_clock: :warning: **DO NOT MERGE YET** :warning: :alarm_clock: 

I want to test this out on TeamCity and ensure the report processing, etc., all works correctly before getting it merged.
