### PR TITLE
Fix #142: Typo in the default end date for the voting cookie

### DIFF
--- a/DDDEastAnglia/Models/VotingCookie.cs
+++ b/DDDEastAnglia/Models/VotingCookie.cs
@@ -8,7 +8,7 @@ namespace DDDEastAnglia.Models
     public class VotingCookie
     {
         public const string CookieName = "DDDEA2013.Voting";
-        public static readonly DateTime DefaultExpiry = new DateTime(2013, 4, 30);
+        public static readonly DateTime DefaultExpiry = new DateTime(2013, 5, 30);
         private readonly List<int> _sessionsVotedFor = new List<int>();
 
         public VotingCookie(Guid id, IEnumerable<int> sessionsVotedFor)


### PR DESCRIPTION
Fix the default end-date for the voting cookies - we will need to make come from the database at some point
