### PR TITLE
Fix #141: fix cookie end date

### DIFF
--- a/DDDEastAnglia/Models/VotingCookie.cs
+++ b/DDDEastAnglia/Models/VotingCookie.cs
@@ -8,7 +8,7 @@ namespace DDDEastAnglia.Models
     public class VotingCookie
     {
         public const string CookieName = "DDDEA2013.Voting";
-        public static readonly DateTime DefaultExpiry = new DateTime(2013, 4, 30);
+        public static readonly DateTime DefaultExpiry = new DateTime(2013, 5, 30);
         private readonly List<int> _sessionsVotedFor = new List<int>();
 
         public VotingCookie(Guid id, IEnumerable<int> sessionsVotedFor)

--- a/DDDEastAnglia/Models/VotingCookie.cs
+++ b/DDDEastAnglia/Models/VotingCookie.cs
@@ -8,7 +8,7 @@ namespace DDDEastAnglia.Models
     public class VotingCookie
     {
         public const string CookieName = "DDDEA2013.Voting";
-        public static readonly DateTime DefaultExpiry = new DateTime(2013, 5, 30);
+        public static readonly DateTime DefaultExpiry = new DateTime(2013, 5, 24);
         private readonly List<int> _sessionsVotedFor = new List<int>();
 
         public VotingCookie(Guid id, IEnumerable<int> sessionsVotedFor)


### PR DESCRIPTION
Set the cookie expiry date to be the date voting closes: 24 May.

I'm now not convinced this is the correct change to make, but hopefully another pair of eyes will be able to say one way or the other.
