### PR TITLE
Fix wrapping of new message on Sessions page.

### DIFF
--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -282,5 +282,5 @@ a i {
 
 .form-search {
     margin-top: 15px;
-    margin-bottom: 25px;
+    margin-bottom: 15px;
 }


### PR DESCRIPTION
It was being forced to wrap by the large bottom margin on the Search box. I fixed it by dropping this value by 10px; we can revisit another time if needed.
