### PR TITLE
Add Eventbrite integration for registration

### DIFF
--- a/DDDEastAnglia/Controllers/HomeController.cs
+++ b/DDDEastAnglia/Controllers/HomeController.cs
@@ -33,5 +33,10 @@ namespace DDDEastAnglia.Controllers
         {
             return View();
         }
+
+        public ActionResult Register()
+        {
+            return View();
+        }
     }
 }

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -524,6 +524,7 @@
       <SubType>Code</SubType>
     </Content>
     <Content Include="Views\Shared\_SearchBox.cshtml" />
+    <Content Include="Views\Home\Register.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/DDDEastAnglia/Views/Home/Register.cshtml
+++ b/DDDEastAnglia/Views/Home/Register.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+    ViewBag.Title = "Register";
+}
+
+<h2>Register</h2>
+
+<p>
+    Registration will open at 1.30pm on Monday 3 June.
+</p>
+
+<div style="width:100%; text-align:left;"><iframe src="http://www.eventbrite.co.uk/tickets-external?eid=5821705879&ref=etckt&v=2" frameborder="0" height="214" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:10px; padding:5px 0 5px; margin:2px; width:100%; text-align:left;"><a style="color:#ddd; text-decoration:none;" target="_blank" href="http://www.eventbrite.co.uk/r/etckt">Online Ticketing</a><span style="color:#ddd;"> for </span><a style="color:#ddd; text-decoration:none;" target="_blank" href="http://dddea2013.eventbrite.co.uk?ref=etckt">DDD East Anglia</a> <span style="color:#ddd;">powered by</span> <a style="color:#ddd; text-decoration:none;" target="_blank" href="http://www.eventbrite.co.uk?ref=etckt">Eventbrite</a></div></div>

--- a/DDDEastAnglia/Views/Shared/_Layout.cshtml
+++ b/DDDEastAnglia/Views/Shared/_Layout.cshtml
@@ -53,6 +53,7 @@
                             <li class="dropdown @Html.MenuState("Session")">@Html.ActionLink("Sessions", "Index", "Session")</li>
                             <li class="dropdown @Html.MenuState("Speaker", "Index")">@Html.ActionLink("Speakers", "Index", "Speaker")</li>
                             @*<li class="dropdown">@Html.ActionLink("Agenda", MVC.Agenda.Index())</li>*@
+                            <li class="dropdown @Html.MenuState("Home", "Register")">@Html.ActionLink("Register", "Register", "Home")</li>
                             <li class="dropdown @Html.MenuState("Home", "About")">@Html.ActionLink("New to DDD?", "About", "Home")</li>
                             <li class="dropdown @Html.MenuState("Home", "Venue")">@Html.ActionLink("Venue", "Venue", "Home")</li>
                             <li class="dropdown @Html.MenuState("Home", "Sponsors")">@Html.ActionLink("Sponsors", "Sponsors", "Home")</li>


### PR DESCRIPTION
I have added two items from Eventbrite:
1. A countdown widget in the sidebar, to replace the existing event details. 
2. A registration page containing the registration form, linked from the nav bar.

Thanks to the caching we're already doing on the website, and the fact that the registration form is served from Eventbrite via an iframe, I think we will be able to do registration through our website rather than pointing people at Eventbrite. We can always use the Eventbrite URL as a fall-back. 
