### PR TITLE
Filter out speakers (and their sessions) that have not been selected

### DIFF
--- a/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
+++ b/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
@@ -87,6 +87,10 @@
     <Compile Include="Helpers\Email\Smtp\SmtpHostSettings_Should.cs" />
     <Compile Include="Helpers\Given_An_IPV4_Address_MatchIPAddress_Should.cs" />
     <Compile Include="Helpers\Given_A_List_Of_Sessions.cs" />
+    <Compile Include="Helpers\Sessions\AllSessionsLoaderShould.cs" />
+    <Compile Include="Helpers\Sessions\SelectedSpeakerProfileFilterShould.cs" />
+    <Compile Include="Helpers\Sessions\SelectedSessionsLoaderShould.cs" />
+    <Compile Include="Helpers\Sessions\SubmittedSessionProfileFilterShould.cs" />
     <Compile Include="NavigationMenu\MenuStateFactoryShould.cs" />
     <Compile Include="NavigationMenu\MenuStateShould.cs" />
     <Compile Include="NavigationMenu\UrlHelperFactoryShould.cs" />

--- a/DDDEastAnglia.Tests/Helpers/Sessions/AllSessionsLoaderShould.cs
+++ b/DDDEastAnglia.Tests/Helpers/Sessions/AllSessionsLoaderShould.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using DDDEastAnglia.DataAccess.EntityFramework;
+using DDDEastAnglia.Helpers.Sessions;
+using DDDEastAnglia.Models;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Helpers.Sessions
+{
+    [TestFixture]
+    public sealed class AllSessionsLoaderShould
+    {
+        [Test]
+        public void ThrowAnException_WhenConstructedWithANullContext()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AllSessionsLoader(null));
+        }
+
+        [Test]
+        public void ThrowAnException_WhenGivenANullProfile()
+        {
+            var db = Substitute.For<IDDDEAContext>();
+            var sessionsLoader = new AllSessionsLoader(db);
+            Assert.Throws<ArgumentNullException>(() => sessionsLoader.LoadSessions(null));
+        }
+
+        [Test]
+        public void OnlyReturnSessionsForTheSpecifiedSpeaker()
+        {
+            var db = Substitute.For<IDDDEAContext>();
+            var session1 = new Session {SpeakerUserName = "bob"};
+            var session3 = new Session {SpeakerUserName = "bob"};
+            db.Sessions.Returns(new[] {session1, new Session {SpeakerUserName = "fred"}, session3});
+            var sessionsLoader = new AllSessionsLoader(db);
+
+            var sessions = sessionsLoader.LoadSessions(new UserProfile {UserName = "bob"});
+
+            CollectionAssert.AreEqual(new[] {session1, session3}, sessions);
+        }
+    }
+}

--- a/DDDEastAnglia.Tests/Helpers/Sessions/SelectedSessionsLoaderShould.cs
+++ b/DDDEastAnglia.Tests/Helpers/Sessions/SelectedSessionsLoaderShould.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using DDDEastAnglia.DataAccess.EntityFramework;
+using DDDEastAnglia.Helpers.Sessions;
+using DDDEastAnglia.Models;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Helpers.Sessions
+{
+    [TestFixture]
+    public sealed class SelectedSessionsLoaderShould
+    {
+        [Test]
+        public void ThrowAnException_WhenConstructedWithANullContext()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SelectedSessionsLoader(null));
+        }
+
+        [Test]
+        public void ThrowAnException_WhenGivenANullProfile()
+        {
+            var db = Substitute.For<IDDDEAContext>();
+            var sessionsLoader = new SelectedSessionsLoader(db);
+            Assert.Throws<ArgumentNullException>(() => sessionsLoader.LoadSessions(null));
+        }
+
+        [Test]
+        public void OnlyReturnSelectedSessionsForTheSpecifiedSpeaker()
+        {
+            var db = Substitute.For<IDDDEAContext>();
+            var session1 = new Session {SpeakerUserName = "bob", SessionId = 1234};
+            var session3 = new Session {SpeakerUserName = "bob", SessionId = 44};
+            db.Sessions.Returns(new[] {session1, new Session {SpeakerUserName = "fred"}, session3});
+            var sessionsLoader = new SelectedSessionsLoader(db);
+
+            var sessions = sessionsLoader.LoadSessions(new UserProfile {UserName = "bob"});
+
+            CollectionAssert.AreEqual(new[] {session3}, sessions);
+        }
+    }
+}

--- a/DDDEastAnglia.Tests/Helpers/Sessions/SelectedSpeakerProfileFilterShould.cs
+++ b/DDDEastAnglia.Tests/Helpers/Sessions/SelectedSpeakerProfileFilterShould.cs
@@ -1,0 +1,24 @@
+﻿using DDDEastAnglia.Helpers.Sessions;
+using DDDEastAnglia.Models;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Helpers.Sessions
+{
+    [TestFixture]
+    public sealed class SelectedSpeakerProfileFilterShould
+    {
+        [Test]
+        public void FilterOutUsersWhoHaveNotBeenSelected()
+        {
+            var profileFilter = new SelectedSpeakerProfileFilter();
+
+            var profile1 = new UserProfile {UserId = 123};
+            var profile2 = new UserProfile {UserId = 48};
+            var profile3 = new UserProfile {UserId = 456};
+
+            var profiles = profileFilter.FilterProfiles(new[] {profile1, profile2, profile3});
+
+            CollectionAssert.AreEquivalent(new[] {profile2}, profiles);
+        }
+    }
+}

--- a/DDDEastAnglia.Tests/Helpers/Sessions/SubmittedSessionProfileFilterShould.cs
+++ b/DDDEastAnglia.Tests/Helpers/Sessions/SubmittedSessionProfileFilterShould.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using DDDEastAnglia.DataAccess.EntityFramework;
+using DDDEastAnglia.Helpers.Sessions;
+using DDDEastAnglia.Models;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Helpers.Sessions
+{
+    [TestFixture]
+    public sealed class SubmittedSessionProfileFilterShould
+    {
+        [Test]
+        public void ThrowAnException_WhenConstructedWithANullContext()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SubmittedSessionProfileFilter(null));
+        }
+
+        [Test]
+        public void FilterOutUsersWhoHaveNotSubmittedSessions()
+        {
+            var context = Substitute.For<IDDDEAContext>();
+            var profileFilter = new SubmittedSessionProfileFilter(context);
+
+            var profile1 = new UserProfile {UserName = "fred"};
+            var profile2 = new UserProfile {UserName = "george"};
+            var profile3 = new UserProfile {UserName = "bob"};
+
+            context.Sessions.Returns(new[] {new Session {SpeakerUserName = "bob"}});
+
+            var profiles = profileFilter.FilterProfiles(new[] {profile1, profile2, profile3});
+
+            CollectionAssert.AreEquivalent(new[] {profile3}, profiles);
+        }
+    }
+}

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -201,6 +201,13 @@
   <ItemGroup>
     <Compile Include="Areas\Admin\Models\VotersPerIPAddressViewModel.cs" />
     <Compile Include="Areas\Admin\Models\VotesPerDayViewModel.cs" />
+    <Compile Include="Helpers\Sessions\AllSessionsLoader.cs" />
+    <Compile Include="Helpers\Sessions\ISessionLoader.cs" />
+    <Compile Include="Helpers\Sessions\IUserProfileFilter.cs" />
+    <Compile Include="Helpers\Sessions\SelectedSessions.cs" />
+    <Compile Include="Helpers\Sessions\SelectedSessionsLoader.cs" />
+    <Compile Include="Helpers\Sessions\SelectedSpeakerProfileFilter.cs" />
+    <Compile Include="Helpers\Sessions\SubmittedSessionProfileFilter.cs" />
     <Compile Include="Helpers\ChartDataFormatter.cs" />
     <Compile Include="VotingData\DataProviderFactory.cs" />
     <Content Include="Content\Site_print.css" />

--- a/DDDEastAnglia/DataAccess/EntityFramework/DDDEAContext.cs
+++ b/DDDEastAnglia/DataAccess/EntityFramework/DDDEAContext.cs
@@ -10,6 +10,7 @@ namespace DDDEastAnglia.DataAccess.EntityFramework
     public interface IDDDEAContext
     {
         IList<UserProfile> UserProfiles{get;}
+        IList<Session> Sessions{get;}
     }
 
     public class DDDEAContextWrapper : IDDDEAContext
@@ -27,6 +28,7 @@ namespace DDDEastAnglia.DataAccess.EntityFramework
         }
 
         public IList<UserProfile> UserProfiles{get {return context.UserProfiles.ToList();}}
+        public IList<Session> Sessions{get {return context.Sessions.ToList();}}
     }
 
     public class DDDEAContext : DbContext

--- a/DDDEastAnglia/Helpers/Sessions/AllSessionsLoader.cs
+++ b/DDDEastAnglia/Helpers/Sessions/AllSessionsLoader.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DDDEastAnglia.DataAccess.EntityFramework;
+using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public class AllSessionsLoader : ISessionLoader
+    {
+        private readonly IDDDEAContext db;
+
+        public AllSessionsLoader(IDDDEAContext db)
+        {
+            if (db == null)
+            {
+                throw new ArgumentNullException("db");
+            }
+            
+            this.db = db;
+        }
+
+        public IEnumerable<Session> LoadSessions(UserProfile profile)
+        {
+            if (profile == null)
+            {
+                throw new ArgumentNullException("profile");
+            }
+            
+            return db.Sessions.Where(s => s.SpeakerUserName == profile.UserName);
+        }
+    }
+}

--- a/DDDEastAnglia/Helpers/Sessions/ISessionLoader.cs
+++ b/DDDEastAnglia/Helpers/Sessions/ISessionLoader.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public interface ISessionLoader
+    {
+        IEnumerable<Session> LoadSessions(UserProfile profile);
+    }
+}

--- a/DDDEastAnglia/Helpers/Sessions/IUserProfileFilter.cs
+++ b/DDDEastAnglia/Helpers/Sessions/IUserProfileFilter.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public interface IUserProfileFilter
+    {
+        IEnumerable<UserProfile> FilterProfiles(IEnumerable<UserProfile> profiles);
+    }
+}

--- a/DDDEastAnglia/Helpers/Sessions/SelectedSessions.cs
+++ b/DDDEastAnglia/Helpers/Sessions/SelectedSessions.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public static class SelectedSessions
+    {
+        public static IEnumerable<int> SpeakerIds
+        {
+            get
+            {
+                return new[]
+                    {
+                                48, // Mark Rendle
+                                62, // Liam Westley
+                                53, // Ian Russell
+                                66, // George Adamson
+                                76, // Randolph Burt,
+                                85, // Chris O'Dell
+                                11, // David Simner
+                                78, // Kevin Boyle
+                                59, // Rob Ashton
+                                81, // Niall Merrigan
+                                22, // John Stovin
+                                75, // Isaac Abraham
+                                20, // Dave Sussman
+                                47, // Thomas Petricek
+                                23 // Joel Hammond-Turner
+                    };
+            }
+        }
+
+        public static IEnumerable<int> SessionIds
+        {
+            get
+            {
+                return new[]
+                    {
+                                44, // Mark Rendle
+                                75, // Liam Westley
+                                46, // Ian Russell
+                                92, // George Adamson
+                                64, // Randolph Burt,
+                                88, // Chris O'Dell
+                                22, // David Simner
+                                68, // Kevin Boyle
+                                55, // Rob Ashton
+                                74, // Niall Merrigan
+                                34, // John Stovin
+                                63, // Isaac Abraham
+                                13, // Dave Sussman
+                                42, // Thomas Petricek
+                                16 // Joel Hammond-Turner
+                    };
+            }
+        }
+    }
+}

--- a/DDDEastAnglia/Helpers/Sessions/SelectedSessionsLoader.cs
+++ b/DDDEastAnglia/Helpers/Sessions/SelectedSessionsLoader.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DDDEastAnglia.DataAccess.EntityFramework;
+using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public class SelectedSessionsLoader : ISessionLoader
+    {
+        private readonly IDDDEAContext context;
+
+        public SelectedSessionsLoader(IDDDEAContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            
+            this.context = context;
+        }
+
+        public IEnumerable<Session> LoadSessions(UserProfile profile)
+        {
+            if (profile == null)
+            {
+                throw new ArgumentNullException("profile");
+            }
+            
+            return context.Sessions.Where(s => s.SpeakerUserName == profile.UserName
+                                                && SelectedSessions.SessionIds.Contains(s.SessionId));
+        }
+    }
+}

--- a/DDDEastAnglia/Helpers/Sessions/SelectedSpeakerProfileFilter.cs
+++ b/DDDEastAnglia/Helpers/Sessions/SelectedSpeakerProfileFilter.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public class SelectedSpeakerProfileFilter : IUserProfileFilter
+    {
+        public IEnumerable<UserProfile> FilterProfiles(IEnumerable<UserProfile> profiles)
+        {
+            return profiles.Where(p => SelectedSessions.SpeakerIds.Contains(p.UserId));
+        }
+    }
+}

--- a/DDDEastAnglia/Helpers/Sessions/SubmittedSessionProfileFilter.cs
+++ b/DDDEastAnglia/Helpers/Sessions/SubmittedSessionProfileFilter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DDDEastAnglia.DataAccess.EntityFramework;
+using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.Helpers.Sessions
+{
+    public class SubmittedSessionProfileFilter : IUserProfileFilter
+    {
+        private readonly IDDDEAContext context;
+
+        public SubmittedSessionProfileFilter(IDDDEAContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+            
+            this.context = context;
+        }
+
+        public IEnumerable<UserProfile> FilterProfiles(IEnumerable<UserProfile> profiles)
+        {
+            return profiles.Where(profile => context.Sessions.Any(s => s.SpeakerUserName == profile.UserName));
+        }
+    }
+}

--- a/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Speaker/_SpeakerDetailsPartial.cshtml
@@ -25,7 +25,7 @@
     
     <p>@Html.MarkdownFor(m => @Model.Bio)</p>
 
-    <h4>Submitted Sessions</h4>
+    <h4>Sessions</h4>
     <ul>
     @foreach (var session in @Model.Sessions)
     {


### PR DESCRIPTION
This is a bit clunky as I've hard-coded the ids of the selected speakers/sessions into a static class. Ideally, there needs to be a database schema change so that we can mark speakers/sessions as selected and this code altered to read from there. That can be done as a separate change though, as we really need to filter the list of speakers more urgently.
