### PR TITLE
Stop the images from escaping their containing divs

### DIFF
--- a/DDDEastAnglia/Views/Home/Accommodation.cshtml
+++ b/DDDEastAnglia/Views/Home/Accommodation.cshtml
@@ -40,6 +40,8 @@
             <td>£89.00</td>
         </tr>
     </table>
+    
+    <div class="clearfix"></div>
 </div>
 
 <p>
@@ -75,6 +77,8 @@
             <td>£76.00</td>
         </tr>
     </table>
+
+    <div class="clearfix"></div>
 </div>
 
 <div class="hotel-details">
@@ -114,4 +118,6 @@
             <td>£189</td>
         </tr>
     </table>
+
+    <div class="clearfix"></div>
 </div>


### PR DESCRIPTION
Now that there is less content, some of the images are escaping out of the hotels div.
