### PR TITLE
Switch the Sidgwick Site to West Road

### DIFF
--- a/DDDEastAnglia/Views/Home/Index.cshtml
+++ b/DDDEastAnglia/Views/Home/Index.cshtml
@@ -7,7 +7,7 @@
         <h1>Welcome to DDD East Anglia!</h1>
         
         <p>
-            @Html.DDDEastAnglia() will be returning to Cambridge on 13 September 2014 at Cambridge University's Sidgwick Site.
+            @Html.DDDEastAnglia() will be returning to Cambridge on 13 September 2014 at Cambridge University's West Road Concert Hall.
             Like all <abbr title="Developer! Developer! Developer!">DDD</abbr> community events, @Html.DDDEastAnglia() is free
             to attend, funded entirely through the generosity of our sponsors.
         </p>


### PR DESCRIPTION
We use West Road as the venue everywhere else.
