### PR TITLE
Fix #251 Prevent the agenda being seen unless it should be

### DIFF
--- a/DDDEastAnglia.Tests/ActionResultExtensions.cs
+++ b/DDDEastAnglia.Tests/ActionResultExtensions.cs
@@ -10,5 +10,12 @@ namespace DDDEastAnglia.Tests
             var model = (T) result.Model;
             return model;
         }
+
+        public static string GetRedirectionViewName(this ActionResult actionResult)
+        {
+            var result = (RedirectToRouteResult) actionResult;
+            var viewName = result.RouteValues["action"];
+            return viewName.ToString();
+        }
     }
 }

--- a/DDDEastAnglia.Tests/ConferenceLoaderBuilder.cs
+++ b/DDDEastAnglia.Tests/ConferenceLoaderBuilder.cs
@@ -34,9 +34,21 @@ namespace DDDEastAnglia.Tests
             return this;
         }
 
+        public ConferenceLoaderBuilder WithAgendaNotPublished()
+        {
+            conference.CanPublishAgenda().Returns(false);
+            return this;
+        }
+
         public ConferenceLoaderBuilder WithAgendaPublished()
         {
             conference.CanPublishAgenda().Returns(true);
+            return this;
+        }
+
+        public ConferenceLoaderBuilder WithRegistrationNotOpen()
+        {
+            conference.CanRegister().Returns(false);
             return this;
         }
 

--- a/DDDEastAnglia.Tests/Controllers/HomeControllerTests.cs
+++ b/DDDEastAnglia.Tests/Controllers/HomeControllerTests.cs
@@ -32,5 +32,44 @@ namespace DDDEastAnglia.Tests.Controllers
 
             Assert.That(model.ShowSessionSubmissionLink, Is.True);
         }
+
+        [Test]
+        public void Agenda_ShouldRedirectBackToIndex_WhenTheAgendaCannotBePublished()
+        {
+            var conferenceLoader = new ConferenceLoaderBuilder()
+                                        .WithAgendaNotPublished()
+                                        .Build();
+
+            var controller = new HomeController(conferenceLoader);
+            var viewName = controller.Agenda().GetRedirectionViewName();
+
+            Assert.That(viewName, Is.EqualTo("Index"));
+        }
+
+        [Test]
+        public void Accommodation_ShouldRedirectBackToIndex_WhenRegistrationIsNotOpen()
+        {
+            var conferenceLoader = new ConferenceLoaderBuilder()
+                                        .WithRegistrationNotOpen()
+                                        .Build();
+
+            var controller = new HomeController(conferenceLoader);
+            var viewName = controller.Agenda().GetRedirectionViewName();
+
+            Assert.That(viewName, Is.EqualTo("Index"));
+        }
+
+        [Test]
+        public void Register_ShouldRedirectBackToIndex_WhenRegistrationIsNotOpen()
+        {
+            var conferenceLoader = new ConferenceLoaderBuilder()
+                                        .WithRegistrationNotOpen()
+                                        .Build();
+
+            var controller = new HomeController(conferenceLoader);
+            var viewName = controller.Agenda().GetRedirectionViewName();
+
+            Assert.That(viewName, Is.EqualTo("Index"));
+        }
     }
 }

--- a/DDDEastAnglia/Controllers/HomeController.cs
+++ b/DDDEastAnglia/Controllers/HomeController.cs
@@ -36,6 +36,13 @@ namespace DDDEastAnglia.Controllers
 
         public ActionResult Accommodation()
         {
+            var conference = conferenceLoader.LoadConference();
+
+            if (!conference.CanRegister())
+            {
+                return RedirectToAction("Index");
+            }
+
             return View();
         }
 
@@ -58,11 +65,25 @@ namespace DDDEastAnglia.Controllers
 
         public ActionResult Register()
         {
+            var conference = conferenceLoader.LoadConference();
+
+            if (!conference.CanRegister())
+            {
+                return RedirectToAction("Index");
+            }
+
             return View();
         }
 
         public ActionResult Agenda()
         {
+            var conference = conferenceLoader.LoadConference();
+
+            if (!conference.CanPublishAgenda())
+            {
+                return RedirectToAction("Index");
+            }
+
             return View();
         }
     }


### PR DESCRIPTION
This also restricts access to the registration and accommodation page unless registration is open.
