### PR TITLE
Put the connection strings into a 'secret' file

### DIFF
--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -542,6 +542,10 @@
     <Content Include="Content\font\FontAwesome.otf" />
     <Content Include="Areas\Admin\Views\Voting\DuplicateVotes.cshtml" />
     <Content Include="Areas\Admin\Views\AdminHome\NavigationLinks.cshtml" />
+    <ExcludeFromPackageFiles Include="connectionStringsSecret.config">
+      <FromTarget>Project</FromTarget>
+      <SubType>Designer</SubType>
+    </ExcludeFromPackageFiles>
     <None Include="Scripts\jquery-1.9.1.intellisense.js" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\html5shiv-printshiv.js" />

--- a/DDDEastAnglia/Web.config
+++ b/DDDEastAnglia/Web.config
@@ -15,9 +15,7 @@
     </sectionGroup>
     <section name="glimpse" type="Glimpse.Core.Configuration.Section, Glimpse.Core" />
   </configSections>
-  <connectionStrings>
-    <add name="DDDEastAnglia" connectionString="Data Source=.;Initial Catalog=DDDEastAnglia-livebackup;Integrated Security=True;Pooling=False;Connect Timeout=30" providerName="System.Data.SqlClient" />
-  </connectionStrings>
+  <connectionStrings configSource="connectionStringsSecret.config"/>
   <appSettings file="appSettingsSecret.config">
     <add key="webpages:Version" value="2.0.0.0" />
     <add key="webpages:Enabled" value="false" />

--- a/DDDEastAnglia/connectionStringsSecret.config
+++ b/DDDEastAnglia/connectionStringsSecret.config
@@ -1,0 +1,5 @@
+<connectionStrings>
+    <add name="DDDEastAnglia" 
+         connectionString="Data Source=(local);Initial Catalog=DDDEastAnglia;Integrated Security=True" 
+         providerName="System.Data.SqlClient" />
+</connectionStrings>


### PR DESCRIPTION
Similar to `appSettingsSecret.config`, there is now support for a `connectionStringsSecret.config` file to contain the database connection strings. This file should not be checked into git, and should contain machine-specific connection strings. The connection string on the live sites is configured in the Azure portal.
