### PR TITLE
Remove the extra margin at the top of the page when in 'mobile' view

### DIFF
--- a/DDDEastAnglia/Areas/Admin/Content/admin.css
+++ b/DDDEastAnglia/Areas/Admin/Content/admin.css
@@ -1,5 +1,7 @@
-﻿body {
-    padding-top: 50px;
+﻿@media (min-width: 979px) {
+    body {
+        padding-top: 50px;
+    }
 }
 
 a { text-decoration: underline; }


### PR DESCRIPTION
With it in place, there is a large white space above the top bar.
