### PR TITLE
Don't differentiate between valid and invalid user details when resetting passwords

### DIFF
--- a/DDDEastAnglia.Tests/Controllers/ResetPasswordControllerTests.cs
+++ b/DDDEastAnglia.Tests/Controllers/ResetPasswordControllerTests.cs
@@ -82,47 +82,25 @@ namespace DDDEastAnglia.Tests.Controllers
         }
 
         [Test]
-        public void TestThat_ResetPassword_AddsAValidationError_WhenTheModelHasAValidUserName_ButTheUserProfileCouldNotBeFound()
-        {
-            var controller = new ResetPasswordController(Substitute.For<IUserProfileRepository>(), Substitute.For<IResetPasswordThingy>(), Substitute.For<IResetPasswordEmailSender>());
-
-            var model = new ResetPasswordStepOneModel {UserName = "bob"};
-            controller.ResetPassword(model);
-
-            Assert.That(controller.ModelState.Count, Is.EqualTo(1));
-        }
-
-        [Test]
-        public void TestThat_ResetPassword_RedirectsBackToStepOne_WhenTheModelHasAValidUserName_ButTheUserProfileCouldNotBeFound()
+        public void TestThat_ResetPassword_RedirectsToStepTwo_WhenTheModelHasAValidUserName_ButTheUserProfileCouldNotBeFound()
         {
             var controller = new ResetPasswordController(Substitute.For<IUserProfileRepository>(), Substitute.For<IResetPasswordThingy>(), Substitute.For<IResetPasswordEmailSender>());
 
             var model = new ResetPasswordStepOneModel {UserName = "bob"};
             var result = (ViewResult) controller.ResetPassword(model);
 
-            Assert.That(result.ViewName, Is.EqualTo("Step1"));
+            Assert.That(result.ViewName, Is.EqualTo("Step2"));
         }
 
         [Test]
-        public void TestThat_ResetPassword_AddsAValidationError_WhenTheModelHasAValidEmailAddress_ButTheUserProfileCouldNotBeFound()
-        {
-            var controller = new ResetPasswordController(Substitute.For<IUserProfileRepository>(), Substitute.For<IResetPasswordThingy>(), Substitute.For<IResetPasswordEmailSender>());
-
-            var model = new ResetPasswordStepOneModel {EmailAddress = "bob@example.com"};
-            controller.ResetPassword(model);
-
-            Assert.That(controller.ModelState.Count, Is.EqualTo(1));
-        }
-
-        [Test]
-        public void TestThat_ResetPassword_RedirectsBackToStepOne_WhenTheModelHasAValidEmailAddress_ButTheUserProfileCouldNotBeFound()
+        public void TestThat_ResetPassword_RedirectsToStepTwo_WhenTheModelHasAValidEmailAddress_ButTheUserProfileCouldNotBeFound()
         {
             var controller = new ResetPasswordController(Substitute.For<IUserProfileRepository>(), Substitute.For<IResetPasswordThingy>(), Substitute.For<IResetPasswordEmailSender>());
 
             var model = new ResetPasswordStepOneModel {EmailAddress = "bob@example.com"};
             var result = (ViewResult) controller.ResetPassword(model);
 
-            Assert.That(result.ViewName, Is.EqualTo("Step1"));
+            Assert.That(result.ViewName, Is.EqualTo("Step2"));
         }
 
         [Test]

--- a/DDDEastAnglia/Controllers/ResetPasswordController.cs
+++ b/DDDEastAnglia/Controllers/ResetPasswordController.cs
@@ -70,8 +70,8 @@ namespace DDDEastAnglia.Controllers
 
             if (profile == null)
             {
-                ModelState.AddModelError("", "Could not reset password.");
-                return View("Step1");
+                // could't find the user, but don't want to give that away
+                return View("Step2");
             }
 
             string passwordResetToken = resetPasswordThingy.GeneratePasswordResetToken(profile.UserName, 120);


### PR DESCRIPTION
Currently, you can brute force the site to get a valid username and/or email address as we return the message "Could not reset password" if the user doesn't exist, as opposed to a page that tells you to check your email. This changes that behaviour to not divulge whether or not we have found the user's details.

This is not ideal, as it means that if you guess at your username/password and get it wrong, you will get no reset password email. The correct way to deal with it is to lock the user (ip address?) out after several failed tries, but that it a much bigger and more complex change.
