### PR TITLE
Fix #294 Make it more obvious that we use gravatar for the profile images

### DIFF
--- a/DDDEastAnglia/App_Start/BundleConfig.cs
+++ b/DDDEastAnglia/App_Start/BundleConfig.cs
@@ -43,6 +43,7 @@ namespace DDDEastAnglia
 
             AddScriptBundle(bundles, "~/bundles/voting", "~/Scripts/voting.js");
             AddScriptBundle(bundles, "~/bundles/resolveIPAddress", "~/Scripts/resolveIPAddress.js");
+            AddScriptBundle(bundles, "~/bundles/gravatar", "~/Scripts/gravatar.js");
             AddScriptBundle(bundles, "~/bundles/progressbar", "~/Scripts/progressbar.js");
 
             AddStyleBundle(bundles, "~/Content/common",

--- a/DDDEastAnglia/Controllers/GravatarController.cs
+++ b/DDDEastAnglia/Controllers/GravatarController.cs
@@ -1,0 +1,14 @@
+﻿using System.Web.Mvc;
+using DDDEastAnglia.Helpers;
+
+namespace DDDEastAnglia.Controllers
+{
+    public class GravatarController : Controller
+    {
+        public ContentResult Url(string emailAddress, bool useIdenticon = false, int size = 50)
+        {
+            var url = new GravatarUrl().GetUrl(emailAddress, useIdenticon: useIdenticon, size: size);
+            return new ContentResult { Content = url };
+        }
+    }
+}

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Areas\Admin\Models\VotersPerIPAddressViewModel.cs" />
     <Compile Include="Areas\Admin\Models\VotesPerDayViewModel.cs" />
     <Content Include="Content\common.css" />
+    <Compile Include="Controllers\GravatarController.cs" />
     <Compile Include="Controllers\TimelineController.cs" />
     <Compile Include="Controllers\UserNameFilterAttribute.cs" />
     <Compile Include="DataAccess\CachingVotingCookieFactory.cs" />
@@ -261,6 +262,7 @@
     <Compile Include="Models\SpeakerProfile.cs" />
     <Compile Include="NavigationMenu\NavigationMenuModule.cs" />
     <Compile Include="Helpers\Email\EmailModule.cs" />
+    <Content Include="Scripts\gravatar.js" />
     <Compile Include="VotingData\DataProviderFactory.cs" />
     <Content Include="Areas\Admin\Views\Voting\NumberOfUsersWhoHaveCastXVotes.cshtml" />
     <Content Include="Areas\Admin\Views\Voting\VotesPerDay.cshtml" />

--- a/DDDEastAnglia/Scripts/gravatar.js
+++ b/DDDEastAnglia/Scripts/gravatar.js
@@ -1,0 +1,7 @@
+﻿function updateGravatarPicture(postUrl, emailAddress, pictureId) {
+    $.post(postUrl,
+        { emailAddress: emailAddress }
+    ).done(function (url) {
+        $('#' + pictureId).attr("src", url);
+    });
+}

--- a/DDDEastAnglia/Views/Profile/Edit.cshtml
+++ b/DDDEastAnglia/Views/Profile/Edit.cshtml
@@ -31,7 +31,7 @@
     <div class="control-group">
         @Html.LabelFor(m => Model.EmailAddress, new { @class = "control-label" })
         <div class="controls">
-            @Html.TextBoxFor(m => Model.EmailAddress, new { type = "email" })
+            @Html.TextBoxFor(m => Model.EmailAddress, new { type = "email", id = "emailTextBox", @onblur = "onEmailChanged();" })
             @Html.ValidationMessageFor(m => Model.EmailAddress)
         </div>
     </div>
@@ -61,6 +61,14 @@
     </div>
 
     <div class="control-group">
+        <span class="control-label">Picture</span>
+        <div class="controls">
+            <img id="profilePicture" src="@Model.GravatarUrl()"/>
+            <em>This image is provided by <a href="http://www.gravatar.com" target="_blank">Gravatar</a>, based on your email address.</em>
+        </div>
+    </div>
+    
+    <div class="control-group">
         @Html.LabelFor(m => Model.Bio, new { @class = "control-label" })
         <div class="controls">
             <div id="wmd-button-bar"></div>
@@ -89,10 +97,18 @@
 @section Scripts 
 {
     @Scripts.Render("~/bundles/jqueryval")
-}
+    @Scripts.Render("~/bundles/gravatar")
 
-<script type="text/javascript">
-    var converter = new Markdown.Converter();
-    var editor = new Markdown.Editor(converter);
-    editor.run();
-</script>
+    <script type="text/javascript">
+        function onEmailChanged() {
+            var emailAddress = $("#emailTextBox").val();
+            updateGravatarPicture('@Url.Action("Url", "Gravatar")', emailAddress, "profilePicture");
+        }
+    </script>
+
+    <script type="text/javascript">
+        var converter = new Markdown.Converter();
+        var editor = new Markdown.Editor(converter);
+        editor.run();
+    </script>
+}


### PR DESCRIPTION
This changes adds the profile picture to the edit profile page, with a note saying that we use gravatar. Additionally, when you edit the email address, the profile picture updates to reflect the email address change.
