### PR TITLE
Show a user's login methods on the user details page in the admin area

### DIFF
--- a/DDDEastAnglia.Tests/Admin/UserControllerTests.cs
+++ b/DDDEastAnglia.Tests/Admin/UserControllerTests.cs
@@ -10,13 +10,13 @@ namespace DDDEastAnglia.Tests.Admin
     [TestFixture]
     public class UserControllerTests
     {
+        private IUserProfileRepository userProfileRepository;
+
         [Test]
         public void Details_GetsTheCorrectUserDetails()
         {
             const int userId = 123;
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             controller.Details(userId);
 
@@ -26,9 +26,7 @@ namespace DDDEastAnglia.Tests.Admin
         [Test]
         public void Details_ReturnsA404_WhenTheUserCannotBeFound()
         {
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             var actionResult = controller.Details(123);
 
@@ -39,9 +37,7 @@ namespace DDDEastAnglia.Tests.Admin
         public void Edit_GetsTheCorrectUserDetails()
         {
             const int userId = 123;
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             controller.Edit(userId);
 
@@ -51,9 +47,7 @@ namespace DDDEastAnglia.Tests.Admin
         [Test]
         public void Edit_ReturnsA404_WhenTheUserCannotBeFound()
         {
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             var actionResult = controller.Edit(123);
 
@@ -63,10 +57,8 @@ namespace DDDEastAnglia.Tests.Admin
         [Test]
         public void Edit_SavesTheUserProfileCorrectly()
         {
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
-            var userProfile = new UserProfile {UserName = "fred", Name = "Fred Bloggs", EmailAddress = "fred@example.com"};
+            var controller = CreateController();
+            var userProfile = new UserProfile { UserName = "fred", Name = "Fred Bloggs", EmailAddress = "fred@example.com" };
 
             controller.Edit(userProfile);
 
@@ -76,9 +68,7 @@ namespace DDDEastAnglia.Tests.Admin
         [Test]
         public void Edit_DoesNotSaveTheUserProfile_WhenTheSubmittedDataIsInvalid()
         {
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
             controller.CreateModelStateError();
 
             controller.Edit(new UserProfile());
@@ -90,9 +80,7 @@ namespace DDDEastAnglia.Tests.Admin
         public void Delete_GetsTheCorrectUserDetails()
         {
             const int userId = 123;
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             controller.Delete(userId);
 
@@ -102,9 +90,7 @@ namespace DDDEastAnglia.Tests.Admin
         [Test]
         public void Delete_ReturnsA404_WhenTheUserCannotBeFound()
         {
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             var actionResult = controller.Delete(123);
 
@@ -114,13 +100,19 @@ namespace DDDEastAnglia.Tests.Admin
         [Test]
         public void DeleteConfirmed_DeletesTheCorrectUser()
         {
-            var userProfileRepository = Substitute.For<IUserProfileRepository>();
-            var sessionRepository = Substitute.For<ISessionRepository>();
-            var controller = new UserController(userProfileRepository, sessionRepository);
+            var controller = CreateController();
 
             controller.DeleteConfirmed(123);
 
             userProfileRepository.Received().DeleteUserProfile(123);
+        }
+
+        private UserController CreateController()
+        {
+            userProfileRepository = Substitute.For<IUserProfileRepository>();
+            var accountLoginMethodQuery = Substitute.For<IAccountLoginMethodQuery>();
+            var sessionRepository = Substitute.For<ISessionRepository>();
+            return new UserController(userProfileRepository, accountLoginMethodQuery, sessionRepository);
         }
     }
 }

--- a/DDDEastAnglia/Areas/Admin/Controllers/UserController.cs
+++ b/DDDEastAnglia/Areas/Admin/Controllers/UserController.cs
@@ -11,13 +11,19 @@ namespace DDDEastAnglia.Areas.Admin.Controllers
     public class UserController : Controller
     {
         private readonly IUserProfileRepository userProfileRepository;
+        private readonly IAccountLoginMethodQuery accountLoginMethodQuery;
         private readonly ISessionRepository sessionRepository;
 
-        public UserController(IUserProfileRepository userProfileRepository, ISessionRepository sessionRepository)
+        public UserController(IUserProfileRepository userProfileRepository, IAccountLoginMethodQuery accountLoginMethodQuery, ISessionRepository sessionRepository)
         {
             if (userProfileRepository == null)
             {
                 throw new ArgumentNullException("userProfileRepository");
+            }
+
+            if (accountLoginMethodQuery == null)
+            {
+                throw new ArgumentNullException("accountLoginMethodQuery");
             }
 
             if (sessionRepository == null)
@@ -26,6 +32,7 @@ namespace DDDEastAnglia.Areas.Admin.Controllers
             }
             
             this.userProfileRepository = userProfileRepository;
+            this.accountLoginMethodQuery = accountLoginMethodQuery;
             this.sessionRepository = sessionRepository;
         }
 
@@ -52,7 +59,14 @@ namespace DDDEastAnglia.Areas.Admin.Controllers
         public ActionResult Details(int id)
         {
             var userProfile = userProfileRepository.GetUserProfileById(id);
-            return userProfile == null ? (ActionResult) HttpNotFound() : View(userProfile);
+
+            if (userProfile == null)
+            {
+                return HttpNotFound();
+            }
+
+            userProfile.LoginMethods = accountLoginMethodQuery.GetLoginMethods(id);
+            return View(userProfile);
         }
 
         public ActionResult Edit(int id)

--- a/DDDEastAnglia/Areas/Admin/Views/User/Details.cshtml
+++ b/DDDEastAnglia/Areas/Admin/Views/User/Details.cshtml
@@ -8,6 +8,8 @@
 
 <section class="group-box user-details">
     <p><i class="icon-user"></i> @Model.UserName</p>
+    
+    <p>Logins @Html.Partial("_LoginMethods", Model.LoginMethods)</p>
 
     @if (!string.IsNullOrWhiteSpace(@Model.EmailAddress))
     {

--- a/DDDEastAnglia/Areas/Admin/Views/User/_LoginMethods.cshtml
+++ b/DDDEastAnglia/Areas/Admin/Views/User/_LoginMethods.cshtml
@@ -1,0 +1,21 @@
+﻿@model DDDEastAnglia.Models.LoginMethods
+
+@if (Model.DDDEA)
+{
+    <i class="icon-user" title="DDDEA Account"></i>
+}
+
+@if (Model.GitHub)
+{
+    <i class="icon-github" title="GitHub"></i>
+}
+
+@if (Model.Twitter)
+{
+    <i class="icon-twitter" title="Twitter"></i>
+}
+
+@if (Model.Google)
+{
+    <i class="icon-google-plus" title="Google"></i>
+}

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -233,7 +233,10 @@
     <Compile Include="Controllers\UserNameFilterAttribute.cs" />
     <Compile Include="DataAccess\CachingVotingCookieFactory.cs" />
     <Compile Include="DataAccess\ConferenceLoader.cs" />
+    <Compile Include="DataAccess\IAccountLoginMethodQuery.cs" />
     <Compile Include="DataAccess\ISpeakerRepository.cs" />
+    <Compile Include="Models\LoginMethods.cs" />
+    <Compile Include="DataAccess\SimpleData\Queries\AccountLoginMethodQuery.cs" />
     <Compile Include="DataAccess\SpeakerRepository.cs" />
     <Compile Include="DataAccess\SimpleData\CalendarItemRepository.cs" />
     <Compile Include="DataAccess\SimpleData\UserProfileRepository.cs" />
@@ -562,6 +565,7 @@
     <Content Include="Areas\Admin\Views\User\Edit.cshtml" />
     <Content Include="Areas\Admin\Views\User\Delete.cshtml" />
     <Content Include="Areas\Admin\Views\Speaker\Index.cshtml" />
+    <Content Include="Areas\Admin\Views\User\_LoginMethods.cshtml" />
     <None Include="Scripts\jquery-1.9.1.intellisense.js" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\html5shiv-printshiv.js" />

--- a/DDDEastAnglia/DataAccess/IAccountLoginMethodQuery.cs
+++ b/DDDEastAnglia/DataAccess/IAccountLoginMethodQuery.cs
@@ -1,0 +1,9 @@
+﻿using DDDEastAnglia.Models;
+
+namespace DDDEastAnglia.DataAccess
+{
+    public interface IAccountLoginMethodQuery
+    {
+        LoginMethods GetLoginMethods(int userId);
+    }
+}

--- a/DDDEastAnglia/DataAccess/SimpleData/Queries/AccountLoginMethodQuery.cs
+++ b/DDDEastAnglia/DataAccess/SimpleData/Queries/AccountLoginMethodQuery.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using DDDEastAnglia.Models;
+using Simple.Data;
+
+namespace DDDEastAnglia.DataAccess.SimpleData.Queries
+{
+    public class AccountLoginMethodQuery : IAccountLoginMethodQuery
+    {
+        private readonly dynamic db = Database.OpenNamedConnection("DDDEastAnglia");
+
+        public LoginMethods GetLoginMethods(int userId)
+        {
+            var dddeaLogin = db.webpages_Membership.FindByUserId(userId);
+            bool hasDddeaLogin = dddeaLogin != null;
+            
+            List<string> oauthLogins = db.webpages_OAuthMembership.FindAllByUserId(userId)
+                                         .Select(db.webpages_OAuthMembership.Provider).ToScalarList<string>();
+            bool hasGitHubLogin = oauthLogins.Contains("github");
+            bool hasTwitterLogin = oauthLogins.Contains("twitter");
+            bool hasGoogleLogin = oauthLogins.Contains("google");
+            
+            return new LoginMethods
+            {
+                DDDEA = hasDddeaLogin,
+                GitHub = hasGitHubLogin,
+                Twitter = hasTwitterLogin,
+                Google = hasGoogleLogin
+            };
+        }
+    }
+}

--- a/DDDEastAnglia/Models/LoginMethods.cs
+++ b/DDDEastAnglia/Models/LoginMethods.cs
@@ -1,0 +1,10 @@
+﻿namespace DDDEastAnglia.Models
+{
+    public class LoginMethods
+    {
+        public bool DDDEA { get; set; }
+        public bool GitHub { get; set; }
+        public bool Twitter { get; set; }
+        public bool Google { get; set; }
+    }
+}

--- a/DDDEastAnglia/Models/UserProfile.cs
+++ b/DDDEastAnglia/Models/UserProfile.cs
@@ -40,6 +40,8 @@ namespace DDDEastAnglia.Models
 
         public DateTimeOffset? JoinedAt { get; set; }
 
+        public LoginMethods LoginMethods { get; set; }
+
         public string GravatarUrl(int size = 50)
         {
             return new GravatarUrl().GetUrl(EmailAddress, size: size);


### PR DESCRIPTION
We have had a few people who can't login because they originally used a provider (e.g. GitHub), but are then trying to log in via another mechanism. This change shows a user's available login methods in the admin section, so we can easily point them in the right direction.
