### PR TITLE
move the spacing from the voting buttons to the session titles

### DIFF
--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -146,6 +146,7 @@ footer span {
 .session-details h3 {
     margin-top: 0;
     margin-bottom: 5px;
+    margin-right: 120px;
     padding-bottom: 2px;
 }
 
@@ -208,8 +209,6 @@ footer span {
 
 .voting {
     display: inline-block;
-    width: 120px;
-    text-align: right;
 }
 
 .form-search {


### PR DESCRIPTION
A previous change set the voting button space to be a fixed width so that when placing a vote and the button text changes size causing the button to get wider, the session title doesn't then move around. This causes the edit and delete links that appear on a user's own sessions to have excessive spacing between them and the voting button.

This change puts a margin on the right of the session title instead to achieve the same result without the unwanted side effects.
