### PR TITLE
Don't include the controls' text in the search

### DIFF
--- a/DDDEastAnglia/Areas/Admin/Views/Session/Index.cshtml
+++ b/DDDEastAnglia/Areas/Admin/Views/Session/Index.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = "Sessions";
 }
 
-@Html.Partial("_SearchBox", new ViewDataDictionary { { "containerClass", "tbody tr" }, { "childSelector", "td" } })
+@Html.Partial("_SearchBox", new ViewDataDictionary { { "containerClass", "tbody tr" }, { "childSelector", "td:not(.controls)" } })
 
 <h2>@ViewBag.Title</h2>
 

--- a/DDDEastAnglia/Areas/Admin/Views/Speaker/Index.cshtml
+++ b/DDDEastAnglia/Areas/Admin/Views/Speaker/Index.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = "Speakers";
 }
 
-@Html.Partial("_SearchBox", new ViewDataDictionary { { "containerClass", "tbody tr" }, { "childSelector", "td" } })
+@Html.Partial("_SearchBox", new ViewDataDictionary { { "containerClass", "tbody tr" }, { "childSelector", "td:not(.controls)" } })
 
 <h2>@ViewBag.Title</h2>
 

--- a/DDDEastAnglia/Areas/Admin/Views/User/Index.cshtml
+++ b/DDDEastAnglia/Areas/Admin/Views/User/Index.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = "Users";
 }
 
-@Html.Partial("_SearchBox", new ViewDataDictionary { { "containerClass", "tbody tr" }, { "childSelector", "td" } })
+@Html.Partial("_SearchBox", new ViewDataDictionary { { "containerClass", "tbody tr" }, { "childSelector", "td:not(.controls)" } })
 
 <h2>@ViewBag.Title</h2>
 


### PR DESCRIPTION
The search box was searching on the text of the controls, meaning that if you typed "edit", all rows matched.
