### PR TITLE
Show stats after voting closes

### DIFF
--- a/DDDEastAnglia/Areas/Admin/Controllers/AdminHomeController.cs
+++ b/DDDEastAnglia/Areas/Admin/Controllers/AdminHomeController.cs
@@ -35,7 +35,7 @@ namespace DDDEastAnglia.Areas.Admin.Controllers
         private MenuViewModel CreateMenuViewModel()
         {
             var conference = conferenceLoader.LoadConference();
-            bool showVotingStats = conference.CanVote() || conference.CanPublishAgenda() || conference.CanRegister();
+            bool showVotingStats = conference.CanVote() || conference.AgendaBeingPrepared() || conference.CanPublishAgenda() || conference.CanRegister();
             var menuViewModel = new MenuViewModel {ShowVotingStatsLink = showVotingStats};
             return menuViewModel;
         }

--- a/DDDEastAnglia/Domain/Calendar/CalendarEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/CalendarEntry.cs
@@ -2,29 +2,29 @@ namespace DDDEastAnglia.Domain.Calendar
 {
     public abstract class CalendarEntry
     {
-        private readonly int _id;
-        private readonly CalendarEntryType _entryType;
-        private readonly string _description;
-        private readonly bool _isPublic;
-        private readonly bool _isAuthorised;
+        private readonly int id;
+        private readonly CalendarEntryType entryType;
+        private readonly string description;
+        private readonly bool isPublic;
+        private readonly bool isAuthorised;
 
         protected CalendarEntry(int id, CalendarEntryType entryType, string description, bool isPublic, bool isAuthorised)
         {
-            _id = id;
-            _entryType = entryType;
-            _description = description;
-            _isPublic = isPublic;
-            _isAuthorised = isAuthorised;
+            this.id = id;
+            this.entryType = entryType;
+            this.description = description;
+            this.isPublic = isPublic;
+            this.isAuthorised = isAuthorised;
         }
 
         public bool IsAuthorised()
         {
-            return _isAuthorised;
+            return isAuthorised;
         }
 
         public CalendarEntryType GetEntryType()
         {
-            return _entryType;
+            return entryType;
         }
 
         public abstract bool IsOpen();

--- a/DDDEastAnglia/Domain/Calendar/CalendarEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/CalendarEntry.cs
@@ -28,5 +28,7 @@ namespace DDDEastAnglia.Domain.Calendar
         }
 
         public abstract bool IsOpen();
+        public abstract bool HasPassed();
+        public abstract bool YetToOpen();
     }
 }

--- a/DDDEastAnglia/Domain/Calendar/NullCalendarEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/NullCalendarEntry.cs
@@ -4,11 +4,19 @@ namespace DDDEastAnglia.Domain.Calendar
     {
         public NullCalendarEntry()
             : base(0, CalendarEntryType.Unknown, "", false, false)
-        {
-            
-        }
+        {}
 
         public override bool IsOpen()
+        {
+            return false;
+        }
+
+        public override bool HasPassed()
+        {
+            return false;
+        }
+
+        public override bool YetToOpen()
         {
             return false;
         }

--- a/DDDEastAnglia/Domain/Calendar/SingleTimeEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/SingleTimeEntry.cs
@@ -14,7 +14,17 @@ namespace DDDEastAnglia.Domain.Calendar
 
         public override bool IsOpen()
         {
+            return HasPassed();
+        }
+
+        public override bool HasPassed()
+        {
             return IsAuthorised() && _startDate.UtcDateTime <= DateTime.UtcNow;
+        }
+
+        public override bool YetToOpen()
+        {
+            return !HasPassed();
         }
     }
 }

--- a/DDDEastAnglia/Domain/Calendar/SingleTimeEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/SingleTimeEntry.cs
@@ -4,12 +4,12 @@ namespace DDDEastAnglia.Domain.Calendar
 {
     public class SingleTimeEntry : CalendarEntry
     {
-        private readonly DateTimeOffset _startDate;
+        private readonly DateTimeOffset startDate;
 
         public SingleTimeEntry(int calendarItemId, CalendarEntryType entryType, string description, bool isPublic, bool isAuthorised, DateTimeOffset startDate)
             : base(calendarItemId, entryType, description, isPublic, isAuthorised)
         {
-            _startDate = startDate;
+            this.startDate = startDate;
         }
 
         public override bool IsOpen()
@@ -19,7 +19,7 @@ namespace DDDEastAnglia.Domain.Calendar
 
         public override bool HasPassed()
         {
-            return IsAuthorised() && _startDate.UtcDateTime <= DateTime.UtcNow;
+            return IsAuthorised() && startDate.UtcDateTime <= DateTime.UtcNow;
         }
 
         public override bool YetToOpen()

--- a/DDDEastAnglia/Domain/Calendar/TimeRangeEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/TimeRangeEntry.cs
@@ -4,29 +4,29 @@ namespace DDDEastAnglia.Domain.Calendar
 {
     public class TimeRangeEntry : CalendarEntry
     {
-        private readonly DateTimeOffset _startDate;
-        private readonly DateTimeOffset _endDate;
+        private readonly DateTimeOffset startDate;
+        private readonly DateTimeOffset endDate;
 
         public TimeRangeEntry(int id, CalendarEntryType entryType, string description, bool isPublic, bool isAuthorised, DateTimeOffset startDate, DateTimeOffset endDate)
             : base(id, entryType, description, isPublic, isAuthorised)
         {
-            _startDate = startDate;
-            _endDate = endDate;
+            this.startDate = startDate;
+            this.endDate = endDate;
         }
 
         public override bool IsOpen()
         {
-            return IsAuthorised() && _startDate.UtcDateTime <= DateTime.UtcNow && DateTime.UtcNow <= _endDate.UtcDateTime;
+            return IsAuthorised() && startDate.UtcDateTime <= DateTime.UtcNow && DateTime.UtcNow <= endDate.UtcDateTime;
         }
 
         public override bool HasPassed()
         {
-            return IsAuthorised() && _endDate.UtcDateTime <= DateTime.UtcNow;
+            return IsAuthorised() && endDate.UtcDateTime <= DateTime.UtcNow;
         }
 
         public override bool YetToOpen()
         {
-            return IsAuthorised() && _startDate > DateTime.UtcNow;
+            return IsAuthorised() && startDate > DateTime.UtcNow;
         }
     }
 }

--- a/DDDEastAnglia/Domain/Calendar/TimeRangeEntry.cs
+++ b/DDDEastAnglia/Domain/Calendar/TimeRangeEntry.cs
@@ -18,5 +18,15 @@ namespace DDDEastAnglia.Domain.Calendar
         {
             return IsAuthorised() && _startDate.UtcDateTime <= DateTime.UtcNow && DateTime.UtcNow <= _endDate.UtcDateTime;
         }
+
+        public override bool HasPassed()
+        {
+            return IsAuthorised() && _endDate.UtcDateTime <= DateTime.UtcNow;
+        }
+
+        public override bool YetToOpen()
+        {
+            return IsAuthorised() && _startDate > DateTime.UtcNow;
+        }
     }
 }

--- a/DDDEastAnglia/Domain/Conference.cs
+++ b/DDDEastAnglia/Domain/Conference.cs
@@ -63,6 +63,12 @@ namespace DDDEastAnglia.Domain
             return calendarEntries[CalendarEntryType.Voting].IsOpen();
         }
 
+        public bool AgendaBeingPrepared()
+        {
+            return calendarEntries[CalendarEntryType.Voting].HasPassed()
+                    && calendarEntries[CalendarEntryType.AgendaPublished].YetToOpen();
+        }
+
         public bool CanPublishAgenda()
         {
             return calendarEntries[CalendarEntryType.AgendaPublished].IsOpen();

--- a/DDDEastAnglia/Domain/IConference.cs
+++ b/DDDEastAnglia/Domain/IConference.cs
@@ -13,6 +13,7 @@
         bool CanSubmit();
         bool CanVote();
         bool CanPublishAgenda();
+        bool AgendaBeingPrepared();
         bool CanRegister();
         bool CanShowSessions();
         bool CanShowSpeakers();


### PR DESCRIPTION
Otherwise, we can't see the voting results once voting closes. This change keeps the voting stats visible until the agenda publish date has passed.
