### PR TITLE
Fix #333: Fix google logins

### DIFF
--- a/DDDEastAnglia/App_Start/AuthConfig.cs
+++ b/DDDEastAnglia/App_Start/AuthConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.Web.Configuration;
+using DotNetOpenAuth.GoogleOAuth2;
 using Microsoft.Web.WebPages.OAuth;
 
 namespace DDDEastAnglia
@@ -10,18 +11,20 @@ namespace DDDEastAnglia
             // To let users of this site log in using their accounts from other sites such as Microsoft, Facebook, and Twitter,
             // you must update this site. For more information visit http://go.microsoft.com/fwlink/?LinkID=252166
 
-            // NOTE: if you add/edit this list, be sure to edit the OAuth provider links in 
+            // NOTE: if you add/edit this list, be sure to edit the OAuth provider links in
             //          the menu and the registration page as they don't get picked up automatically
 
             OAuthWebSecurity.RegisterClient(new GitHubOAuthClient(
                 WebConfigurationManager.AppSettings["GitHubAppId"],
                 WebConfigurationManager.AppSettings["GitHubSecret"]), "GitHub", null);
-            
+
             OAuthWebSecurity.RegisterTwitterClient(
                 WebConfigurationManager.AppSettings["TwitterKey"],
                 WebConfigurationManager.AppSettings["TwitterSecret"]);
 
-            OAuthWebSecurity.RegisterGoogleClient();
+            OAuthWebSecurity.RegisterClient(new GoogleOAuth2Client(
+                WebConfigurationManager.AppSettings["GoogleClientId"],
+                WebConfigurationManager.AppSettings["GoogleSecret"]), "Google", null);
         }
     }
 }

--- a/DDDEastAnglia/Controllers/AccountController.cs
+++ b/DDDEastAnglia/Controllers/AccountController.cs
@@ -5,6 +5,7 @@ using System.Web.Mvc;
 using System.Web.Security;
 using DDDEastAnglia.DataAccess;
 using DotNetOpenAuth.AspNet;
+using DotNetOpenAuth.GoogleOAuth2;
 using Microsoft.Web.WebPages.OAuth;
 using WebMatrix.WebData;
 using DDDEastAnglia.Models;
@@ -217,6 +218,7 @@ namespace DDDEastAnglia.Controllers
         [AllowAnonymous]
         public ActionResult ExternalLoginCallback(string returnUrl)
         {
+            GoogleOAuth2Client.RewriteRequest();
             AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action("ExternalLoginCallback", new { ReturnUrl = returnUrl }));
 
             if (!result.IsSuccessful)

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -48,6 +48,33 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetOpenAuth.AspNet, Version=4.2.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotNetOpenAuth.AspNet.4.2.2.13055\lib\net45-full\DotNetOpenAuth.AspNet.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth.Core, Version=4.2.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotNetOpenAuth.Core.4.2.2.13055\lib\net45-full\DotNetOpenAuth.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth.GoogleOAuth2">
+      <HintPath>..\packages\DotNetOpenAuth.GoogleOAuth2.1.1.2\lib\net40\DotNetOpenAuth.GoogleOAuth2.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth.OAuth, Version=4.2.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotNetOpenAuth.OAuth.Core.4.2.2.13055\lib\net45-full\DotNetOpenAuth.OAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth.OAuth.Consumer, Version=4.2.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotNetOpenAuth.OAuth.Consumer.4.2.2.13055\lib\net45-full\DotNetOpenAuth.OAuth.Consumer.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth.OpenId, Version=4.2.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotNetOpenAuth.OpenId.Core.4.2.2.13055\lib\net45-full\DotNetOpenAuth.OpenId.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetOpenAuth.OpenId.RelyingParty, Version=4.2.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotNetOpenAuth.OpenId.RelyingParty.4.2.2.13055\lib\net45-full\DotNetOpenAuth.OpenId.RelyingParty.dll</HintPath>
+    </Reference>
     <Reference Include="MarkdownSharp">
       <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
     </Reference>
@@ -92,10 +119,17 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Security" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -168,30 +202,6 @@
     <Reference Include="WebMatrix.WebData, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.WebData.2.0.20710.0\lib\net40\WebMatrix.WebData.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetOpenAuth.AspNet, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DotNetOpenAuth.AspNet.4.0.3.12153\lib\net40-full\DotNetOpenAuth.AspNet.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetOpenAuth.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DotNetOpenAuth.Core.4.0.3.12153\lib\net40-full\DotNetOpenAuth.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetOpenAuth.OAuth.Consumer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DotNetOpenAuth.OAuth.Consumer.4.0.3.12153\lib\net40-full\DotNetOpenAuth.OAuth.Consumer.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetOpenAuth.OAuth, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DotNetOpenAuth.OAuth.Core.4.0.3.12153\lib\net40-full\DotNetOpenAuth.OAuth.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetOpenAuth.OpenId, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DotNetOpenAuth.OpenId.Core.4.0.3.12153\lib\net40-full\DotNetOpenAuth.OpenId.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetOpenAuth.OpenId.RelyingParty, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2780ccd10d57b246, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DotNetOpenAuth.OpenId.RelyingParty.4.0.3.12153\lib\net40-full\DotNetOpenAuth.OpenId.RelyingParty.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/DDDEastAnglia/Web.config
+++ b/DDDEastAnglia/Web.config
@@ -1,10 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
+    <configSections>
+        <sectionGroup name="dotNetOpenAuth" type="DotNetOpenAuth.Configuration.DotNetOpenAuthSection, DotNetOpenAuth.Core">
+            <section name="messaging" type="DotNetOpenAuth.Configuration.MessagingElement, DotNetOpenAuth.Core" requirePermission="false" allowLocation="true" />
+            <section name="reporting" type="DotNetOpenAuth.Configuration.ReportingElement, DotNetOpenAuth.Core" requirePermission="false" allowLocation="true" />
+            <section name="openid" type="DotNetOpenAuth.Configuration.OpenIdElement, DotNetOpenAuth.OpenId" requirePermission="false" allowLocation="true" />
+            <section name="oauth" type="DotNetOpenAuth.Configuration.OAuthElement, DotNetOpenAuth.OAuth" requirePermission="false" allowLocation="true" />
+        </sectionGroup>
+    </configSections>
+
     <connectionStrings>
         <add name="DDDEastAnglia" connectionString="Data Source=.;Initial Catalog=DDDEastAnglia-livebackup;Integrated Security=True;Pooling=False;Connect Timeout=30" providerName="System.Data.SqlClient" />
     </connectionStrings>
-    
+
     <appSettings file="appSettingsSecret.config">
         <add key="webpages:Version" value="2.0.0.0" />
         <add key="webpages:Enabled" value="false" />
@@ -12,16 +21,16 @@
         <add key="ClientValidationEnabled" value="true" />
         <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     </appSettings>
-    
+
     <system.web>
         <customErrors mode="RemoteOnly" />
         <httpRuntime targetFramework="4.5.1" />
         <compilation debug="true" targetFramework="4.5.1" />
-    
+
         <authentication mode="Forms">
             <forms loginUrl="~/Account/Login" timeout="10080" />
         </authentication>
-        
+
         <pages>
             <namespaces>
                 <add namespace="System.Web.Helpers" />
@@ -37,7 +46,7 @@
 
     <system.webServer>
         <validation validateIntegratedModeConfiguration="false" />
-    
+
         <modules runAllManagedModulesForAllRequests="true" />
 
         <handlers>
@@ -56,7 +65,7 @@
                 </fileExtensions>
             </requestFiltering>
         </security>
-        
+
         <staticContent>
             <remove fileExtension=".woff" />
             <remove fileExtension=".eot" />
@@ -84,6 +93,76 @@
                 <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
             </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="DotNetOpenAuth.AspNet" publicKeyToken="2780ccd10d57b246" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="DotNetOpenAuth.Core" publicKeyToken="2780ccd10d57b246" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
+
+        <!-- This prevents the Windows Event Log from frequently logging that HMAC1 is being used (when the other party needs it). -->
+        <legacyHMACWarning enabled="0" />
+        <!-- When targeting ASP.NET MVC 3, this assemblyBinding makes MVC 1 and 2 references relink
+		     to MVC 3 so libraries such as DotNetOpenAuth that compile against MVC 1 will work with it.
+		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+				<bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+			</dependentAssembly>
+		</assemblyBinding>
+		 -->
     </runtime>
+
+    <system.net>
+        <defaultProxy enabled="true" />
+        <settings>
+            <!-- This setting causes .NET to check certificate revocation lists (CRL) 
+			     before trusting HTTPS certificates.  But this setting tends to not 
+			     be allowed in shared hosting environments. -->
+            <!--<servicePointManager checkCertificateRevocationList="true"/>-->
+        </settings>
+    </system.net>
+
+    <dotNetOpenAuth>
+        <messaging>
+            <untrustedWebRequest>
+                <whitelistHosts>
+                    <!-- Uncomment to enable communication with localhost (should generally not activate in production!) -->
+                    <!--<add name="localhost" />-->
+                </whitelistHosts>
+            </untrustedWebRequest>
+        </messaging>
+
+        <!-- Allow DotNetOpenAuth to publish usage statistics to library authors to improve the library. -->
+        <reporting enabled="false" />
+
+        <!-- This is an optional configuration section where aspects of dotnetopenauth can be customized. -->
+        <!-- For a complete set of configuration options see http://www.dotnetopenauth.net/developers/code-snippets/configuration-options/ -->
+        <openid>
+            <relyingParty>
+                <security requireSsl="false">
+                    <!-- Uncomment the trustedProviders tag if your relying party should only accept positive assertions from a closed set of OpenID Providers. -->
+                    <!--<trustedProviders rejectAssertionsFromUntrustedProviders="true">
+						<add endpoint="https://www.google.com/accounts/o8/ud" />
+					</trustedProviders>-->
+                </security>
+                <behaviors>
+                    <!-- The following OPTIONAL behavior allows RPs to use SREG only, but be compatible
+					     with OPs that use Attribute Exchange (in various formats). -->
+                    <add type="DotNetOpenAuth.OpenId.RelyingParty.Behaviors.AXFetchAsSregTransform, DotNetOpenAuth.OpenId.RelyingParty" />
+                </behaviors>
+            </relyingParty>
+        </openid>
+    </dotNetOpenAuth>
+
+    <uri>
+        <!-- The uri section is necessary to turn on .NET 3.5 support for IDN (international domain names),
+		     which is necessary for OpenID urls with unicode characters in the domain/host name.
+		     It is also required to put the Uri class into RFC 3986 escaping mode, which OpenID and OAuth require. -->
+        <idn enabled="All" />
+        <iriParsing enabled="true" />
+    </uri>
 </configuration>

--- a/DDDEastAnglia/packages.config
+++ b/DDDEastAnglia/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetOpenAuth.AspNet" version="4.0.3.12153" targetFramework="net40" />
-  <package id="DotNetOpenAuth.Core" version="4.0.3.12153" targetFramework="net40" />
-  <package id="DotNetOpenAuth.OAuth.Consumer" version="4.0.3.12153" targetFramework="net40" />
-  <package id="DotNetOpenAuth.OAuth.Core" version="4.0.3.12153" targetFramework="net40" />
-  <package id="DotNetOpenAuth.OpenId.Core" version="4.0.3.12153" targetFramework="net40" />
-  <package id="DotNetOpenAuth.OpenId.RelyingParty" version="4.0.3.12153" targetFramework="net40" />
+  <package id="DotNetOpenAuth.AspNet" version="4.2.2.13055" targetFramework="net451" />
+  <package id="DotNetOpenAuth.Core" version="4.2.2.13055" targetFramework="net451" />
+  <package id="DotNetOpenAuth.GoogleOAuth2" version="1.1.2" targetFramework="net451" />
+  <package id="DotNetOpenAuth.OAuth.Consumer" version="4.2.2.13055" targetFramework="net451" />
+  <package id="DotNetOpenAuth.OAuth.Core" version="4.2.2.13055" targetFramework="net451" />
+  <package id="DotNetOpenAuth.OpenId.Core" version="4.2.2.13055" targetFramework="net451" />
+  <package id="DotNetOpenAuth.OpenId.RelyingParty" version="4.2.2.13055" targetFramework="net451" />
   <package id="FontAwesome" version="3.1.1" targetFramework="net40" />
   <package id="jQuery" version="1.9.1" targetFramework="net40" />
   <package id="jquery.cookie" version="1.3.1" targetFramework="net40" />
@@ -24,8 +25,11 @@
   <package id="Microsoft.AspNet.WebPages.Data" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages.OAuth" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebPages.WebData" version="2.0.20710.0" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net451" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net451" />
   <package id="Microsoft.jQuery.Unobtrusive.Ajax" version="2.0.30116.0" targetFramework="net40" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.30116.0" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net451" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="Modernizr" version="2.6.2" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net451" />


### PR DESCRIPTION
This should fix the Google logins after their upgrade to OAuth2.

I've got round the problem of upgrading existing pre-OAuth2 logins by simply removing them - they are easy enough to recreate.