### PR TITLE
Fix #290 Crash when attempting to reset password using email address

### DIFF
--- a/DDDEastAnglia/DataAccess/SimpleData/UserProfileRepository.cs
+++ b/DDDEastAnglia/DataAccess/SimpleData/UserProfileRepository.cs
@@ -25,7 +25,7 @@ namespace DDDEastAnglia.DataAccess.SimpleData
 
         public UserProfile GetUserProfileByEmailAddress(string emailAddress)
         {
-            return db.UserProfiles.FindUserByEmailAddress(emailAddress);
+            return db.UserProfiles.FindByEmailAddress(emailAddress);
         }
 
         public UserProfile AddUserProfile(UserProfile userProfile)


### PR DESCRIPTION
This fixes the crash when a user attempts to reset their password using their email address.
