### PR TITLE
Added entry for .vs folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ UpgradeLog*.XML
 
 *.mdf
 *.ldf
+
+# Visual Studio 2015 .vs folder
+.vs/


### PR DESCRIPTION
VS2015 adds a .vs folder to the solution folder for .suo files and other cruft, this is to add an entry to .gitignore for that folder
