### PR TITLE
Maintain the submitted date when editing a session

### DIFF
--- a/DDDEastAnglia/Controllers/SessionController.cs
+++ b/DDDEastAnglia/Controllers/SessionController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web.Mvc;
 using DDDEastAnglia.DataAccess;
@@ -109,6 +110,7 @@ namespace DDDEastAnglia.Controllers
 
             if (ModelState.IsValid)
             {
+                session.SubmittedAt = DateTimeOffset.UtcNow;
                 var addedSession = sessionRepository.AddSession(session);
                 return RedirectToAction("Details", new {id = addedSession.SessionId});
             }
@@ -185,7 +187,7 @@ namespace DDDEastAnglia.Controllers
             {
                 return new HttpUnauthorizedResult();
             }
-            
+
             sessionRepository.DeleteSession(id);
             return RedirectToAction("Index");
         }

--- a/DDDEastAnglia/Views/Session/Edit.cshtml
+++ b/DDDEastAnglia/Views/Session/Edit.cshtml
@@ -34,12 +34,13 @@
     <div id="wmd-preview"></div>
 
     <div>
-        <input type="submit" class="btn btn-primary" value="Save changes" />
+        @Html.HiddenFor(m => Model.SubmittedAt)
+        <input type="submit" class="btn btn-primary" value="Save changes"/>
         @Html.ActionLink("Cancel", "Index")
     </div>
 }
 
-@section Scripts 
+@section Scripts
 {
     @Scripts.Render("~/bundles/jqueryval")
 


### PR DESCRIPTION
When a user edits a session, the submitted date was getting overridden. This fixes it.
