### PR TITLE
Don't show the submit session link when submissions are closed

### DIFF
--- a/DDDEastAnglia/Controllers/AccountController.cs
+++ b/DDDEastAnglia/Controllers/AccountController.cs
@@ -16,15 +16,22 @@ namespace DDDEastAnglia.Controllers
     public class AccountController : Controller
     {
         private readonly IUserProfileRepository userProfileRepository;
+        private readonly IConferenceLoader conferenceLoader;
 
-        public AccountController(IUserProfileRepository userProfileRepository)
+        public AccountController(IUserProfileRepository userProfileRepository, IConferenceLoader conferenceLoader)
         {
             if (userProfileRepository == null)
             {
                 throw new ArgumentNullException("userProfileRepository");
             }
-            
+
+            if (conferenceLoader == null)
+            {
+                throw new ArgumentNullException("conferenceLoader");
+            }
+
             this.userProfileRepository = userProfileRepository;
+            this.conferenceLoader = conferenceLoader;
         }
 
         // GET: /Account/Login
@@ -88,7 +95,13 @@ namespace DDDEastAnglia.Controllers
                     profile.EmailAddress = model.EmailAddress;
                     userProfileRepository.UpdateUserProfile(profile);
 
-                    return View("Registered", model);
+                    var conference = conferenceLoader.LoadConference();
+                    var registeredModel = new RegisteredModel
+                    {
+                        UserName = model.UserName,
+                        CanSubmitSessions = conference.CanSubmit()
+                    };
+                    return View("Registered", registeredModel);
                 }
                 catch (MembershipCreateUserException e)
                 {

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -231,6 +231,7 @@
     <Compile Include="DataAccess\ISpeakerRepository.cs" />
     <Compile Include="DataAccess\ISponsorRepository.cs" />
     <Compile Include="DataAccess\DefaultSponsorSorter.cs" />
+    <Compile Include="Models\RegisteredModel.cs" />
     <Compile Include="Models\SponsorLogo.cs" />
     <Compile Include="Helpers\ImageResizeExtensions.cs" />
     <Compile Include="DataAccess\SimpleData\Models\Sponsor.cs" />

--- a/DDDEastAnglia/Models/RegisteredModel.cs
+++ b/DDDEastAnglia/Models/RegisteredModel.cs
@@ -1,0 +1,8 @@
+﻿namespace DDDEastAnglia.Models
+{
+    public class RegisteredModel
+    {
+        public string UserName { get; set; }
+        public bool CanSubmitSessions { get; set; }
+    }
+}

--- a/DDDEastAnglia/Views/Account/Registered.cshtml
+++ b/DDDEastAnglia/Views/Account/Registered.cshtml
@@ -1,4 +1,4 @@
-﻿@model DDDEastAnglia.Models.RegisterModel
+﻿@model DDDEastAnglia.Models.RegisteredModel
 @{
     ViewBag.Title = "Register";
 }
@@ -7,7 +7,10 @@
 
 <p>You have successfully created an account. Please take some time to @Html.ActionLink("update your profile", "Edit", "Profile").</p>
 
-<p>You can now @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
+@if (Model.CanSubmitSessions)
+{
+    <p>You can now @Html.ActionLink("submit a session", "Create", "Session", null, new { @class = "submit-session" }).</p>
+}
 
 @section Scripts {
     @Scripts.Render("~/bundles/jqueryval")


### PR DESCRIPTION
After registration, we show a page that has a link on it encouraging you to submit a session. This was always showing, even when submissions were closed. This stops the link from being shown when session submissions are closed.