### PR TITLE
Throw a better error when the conference can't be found

### DIFF
--- a/DDDEastAnglia/DataAccess/ConferenceLoader.cs
+++ b/DDDEastAnglia/DataAccess/ConferenceLoader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using DDDEastAnglia.DataAccess.SimpleData.Builders;
 using DDDEastAnglia.Domain;
+using Conference = DDDEastAnglia.DataAccess.SimpleData.Models.Conference;
 
 namespace DDDEastAnglia.DataAccess
 {
@@ -36,13 +37,23 @@ namespace DDDEastAnglia.DataAccess
         public IConference LoadConference()
         {
             var dataConference = conferenceRepository.GetByEventShortName(DefaultEventName);
-            return conferenceBuilder.Build(dataConference);
+            return BuildConference(dataConference);
         }
 
         public IConference LoadConference(int sessionId)
         {
             var dataConference = conferenceRepository.ForSession(sessionId);
-            return conferenceBuilder.Build(dataConference);
+            return BuildConference(dataConference);
+        }
+
+        private IConference BuildConference(Conference conference)
+        {
+            if (conference == null)
+            {
+                throw new ArgumentNullException(nameof(conference), "Cannot find current conference");
+            }
+
+            return conferenceBuilder.Build(conference);
         }
     }
 }

--- a/DDDEastAnglia/DataAccess/SimpleData/Builders/ConferenceBuilder.cs
+++ b/DDDEastAnglia/DataAccess/SimpleData/Builders/ConferenceBuilder.cs
@@ -17,11 +17,6 @@ namespace DDDEastAnglia.DataAccess.SimpleData.Builders
 
         public Domain.Conference Build(Conference item)
         {
-            if (item == null)
-            {
-                return null;
-            }
-            
             var conference = new Domain.Conference(item.ConferenceId, item.Name, item.ShortName, item.NumberOfTimeSlots, item.NumberOfTracks, item.AnonymousSessions);
             var calendarItems = calendarItemRepository.GetAll();
 


### PR DESCRIPTION
Currently, it throws a `NullReferenceException` and you have to deduce what is wrong.