### PR TITLE
Show the number of distinct speakers in the summary at the top of the page

### DIFF
--- a/DDDEastAnglia/Areas/Admin/Views/Session/Index.cshtml
+++ b/DDDEastAnglia/Areas/Admin/Views/Session/Index.cshtml
@@ -9,7 +9,10 @@
 <h2>@ViewBag.Title</h2>
 
 <div class="pull-right">
-    <strong>@Model.Count() sessions</strong>
+    @{
+        int speakerCount = Model.Select(s => s.SpeakerUserName).Distinct().Count();
+    }
+    <strong>@Model.Count() sessions from @speakerCount speakers</strong>
 </div>
 
 <table id="sessionsTable" class="table table-striped table-hover table-condensed">


### PR DESCRIPTION
Wanted to be able to see in one hit how many distinct speakers have submitted so we have a slightly better idea of when we have enough