### PR TITLE
Add security headers

### DIFF
--- a/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
+++ b/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Admin\SessionControllerTests.cs" />
     <Compile Include="Admin\UserControllerTests.cs" />
     <Compile Include="DataAccess\DefaultSponsorSorterTests.cs" />
+    <Compile Include="Filters\SecurityHeadersFilterTests.cs" />
     <Compile Include="Helpers\ImageResizeExtensionsTests.cs" />
     <Compile Include="Sponsors\Query\Context.cs" />
     <Compile Include="Sponsors\Query\Sponsors_who_havent_paid_yet.cs" />

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -54,6 +54,7 @@ namespace DDDEastAnglia.Tests.Filters
         [TestCase("X-Frame-Origins")]
         [TestCase("X-XSS-Protection")]
         [TestCase("X-Content-Type-Options")]
+        [TestCase("Strict-Transport-Security")]
         public void Security_Header_Is_Added(string headerName)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
@@ -68,6 +69,7 @@ namespace DDDEastAnglia.Tests.Filters
         [TestCase("X-Frame-Origins", "SAMEORIGIN")]
         [TestCase("X-XSS-Protection", "1; mode=block")]
         [TestCase("X-Content-Type-Options", "nosniff")]
+        [TestCase("Strict-Transport-Security", "max-age=31536000; includeSubDomains")]
         public void Security_Header_Is_Correct_Value(string headerName, string headerValue)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -16,6 +16,8 @@ namespace DDDEastAnglia.Tests.Filters
     public class SecurityHeadersFilterTests
     {
         [TestCase("X-Powered-By", "ASP.NET")]
+        [TestCase("X-ASPNet-Version", "4.0.30319")]
+        [TestCase("x-aspnetmvc-version", "4.0")]
         public void ASPNET_Header_Is_Removed(string headerName, string headerValue)
         {
             HttpContextBase contextBase = Substitute.For<HttpContextBase>();

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -39,5 +39,51 @@ namespace DDDEastAnglia.Tests.Filters
             
             Assert.That(filteredHeaders[headerName], Is.Null);
         }
+
+        [Test]
+        public void Security_Header_Is_Added()
+        {
+            HttpContextBase contextBase = Substitute.For<HttpContextBase>();
+            HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
+            NameValueCollection headers = new NameValueCollection();
+            responseBase.Headers.Returns(headers);
+            contextBase.Response.Returns(responseBase);
+
+            ResultExecutingContext context = new ResultExecutingContext
+            {
+                HttpContext = contextBase
+            };
+
+            SecurityHeadersFilter filter = new SecurityHeadersFilter();
+
+            filter.OnResultExecuting(context);
+
+            NameValueCollection filteredHeaders = responseBase.Headers;
+
+            Assert.That(filteredHeaders["X-Frame-Origins"], Is.Not.Null);
+        }
+
+        [Test]
+        public void Security_Header_Is_Correct_Value()
+        {
+            HttpContextBase contextBase = Substitute.For<HttpContextBase>();
+            HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
+            NameValueCollection headers = new NameValueCollection();
+            responseBase.Headers.Returns(headers);
+            contextBase.Response.Returns(responseBase);
+
+            ResultExecutingContext context = new ResultExecutingContext
+            {
+                HttpContext = contextBase
+            };
+
+            SecurityHeadersFilter filter = new SecurityHeadersFilter();
+
+            filter.OnResultExecuting(context);
+
+            NameValueCollection filteredHeaders = responseBase.Headers;
+
+            Assert.That(filteredHeaders["X-Frame-Origins"], Is.EqualTo("SAMEORIGIN"));
+        }
     }
 }

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -12,16 +12,15 @@ using NUnit.Framework;
 
 namespace DDDEastAnglia.Tests.Filters
 {
-
     [TestFixture]
     public class SecurityHeadersFilterTests
     {
-        [Test]
-        public void XPoweredBy_Header_Is_Removed()
+        [TestCase("X-Powered-By", "ASP.NET")]
+        public void ASPNET_Header_Is_Removed(string headerName, string headerValue)
         {
             HttpContextBase contextBase = Substitute.For<HttpContextBase>();
             HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
-            NameValueCollection headers = new NameValueCollection {{"X-Powered-By", "ASP.NET"}};
+            NameValueCollection headers = new NameValueCollection {{headerName, headerValue}};
             responseBase.Headers.Returns(headers);
             contextBase.Response.Returns(responseBase);
 
@@ -36,7 +35,7 @@ namespace DDDEastAnglia.Tests.Filters
 
             NameValueCollection filteredHeaders = responseBase.Headers;
             
-            Assert.That(filteredHeaders["X-Powered-By"], Is.Null);
+            Assert.That(filteredHeaders[headerName], Is.Null);
         }
     }
 }

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -51,8 +51,8 @@ namespace DDDEastAnglia.Tests.Filters
             Assert.That(filteredHeaders[headerName], Is.Null);
         }
 
-        [Test]
-        public void Security_Header_Is_Added()
+        [TestCase("X-Frame-Origins")]
+        public void Security_Header_Is_Added(string headerName)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
@@ -60,11 +60,11 @@ namespace DDDEastAnglia.Tests.Filters
 
             NameValueCollection filteredHeaders = responseBase.Headers;
 
-            Assert.That(filteredHeaders["X-Frame-Origins"], Is.Not.Null);
+            Assert.That(filteredHeaders[headerName], Is.Not.Null);
         }
 
-        [Test]
-        public void Security_Header_Is_Correct_Value()
+        [TestCase("X-Frame-Origins", "SAMEORIGIN")]
+        public void Security_Header_Is_Correct_Value(string headerName, string headerValue)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
@@ -72,7 +72,7 @@ namespace DDDEastAnglia.Tests.Filters
 
             NameValueCollection filteredHeaders = responseBase.Headers;
 
-            Assert.That(filteredHeaders["X-Frame-Origins"], Is.EqualTo("SAMEORIGIN"));
+            Assert.That(filteredHeaders[headerName], Is.EqualTo(headerValue));
         }
     }
 }

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -15,8 +15,8 @@ namespace DDDEastAnglia.Tests.Filters
     [TestFixture]
     public class SecurityHeadersFilterTests
     {
-        [TestCase("X-Powered-By", "ASP.NET")]
-        [TestCase("X-ASPNet-Version", "4.0.30319")]
+        [TestCase("x-powered-by", "ASP.NET")]
+        [TestCase("x-aspnet-version", "4.0.30319")]
         [TestCase("x-aspnetmvc-version", "4.0")]
         public void ASPNET_Header_Is_Removed(string headerName, string headerValue)
         {

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -15,21 +15,32 @@ namespace DDDEastAnglia.Tests.Filters
     [TestFixture]
     public class SecurityHeadersFilterTests
     {
+        private HttpContextBase contextBase;
+        private HttpResponseBase responseBase;
+        private NameValueCollection headers;
+        private ResultExecutingContext context;
+
+        [SetUp]
+        public void Setup()
+        {
+            contextBase = Substitute.For<HttpContextBase>();
+            responseBase = Substitute.For<HttpResponseBase>();
+            headers = new NameValueCollection();
+            responseBase.Headers.Returns(headers);
+            contextBase.Response.Returns(responseBase);
+
+            context = new ResultExecutingContext
+            {
+                HttpContext = contextBase
+            };
+        }
+
         [TestCase("x-powered-by", "ASP.NET")]
         [TestCase("x-aspnet-version", "4.0.30319")]
         [TestCase("x-aspnetmvc-version", "4.0")]
         public void ASPNET_Header_Is_Removed(string headerName, string headerValue)
         {
-            HttpContextBase contextBase = Substitute.For<HttpContextBase>();
-            HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
-            NameValueCollection headers = new NameValueCollection {{headerName, headerValue}};
-            responseBase.Headers.Returns(headers);
-            contextBase.Response.Returns(responseBase);
-
-            ResultExecutingContext context = new ResultExecutingContext
-            {
-                HttpContext = contextBase
-            };
+            headers.Add(headerName,headerValue);
 
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
@@ -43,17 +54,6 @@ namespace DDDEastAnglia.Tests.Filters
         [Test]
         public void Security_Header_Is_Added()
         {
-            HttpContextBase contextBase = Substitute.For<HttpContextBase>();
-            HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
-            NameValueCollection headers = new NameValueCollection();
-            responseBase.Headers.Returns(headers);
-            contextBase.Response.Returns(responseBase);
-
-            ResultExecutingContext context = new ResultExecutingContext
-            {
-                HttpContext = contextBase
-            };
-
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
             filter.OnResultExecuting(context);
@@ -66,17 +66,6 @@ namespace DDDEastAnglia.Tests.Filters
         [Test]
         public void Security_Header_Is_Correct_Value()
         {
-            HttpContextBase contextBase = Substitute.For<HttpContextBase>();
-            HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
-            NameValueCollection headers = new NameValueCollection();
-            responseBase.Headers.Returns(headers);
-            contextBase.Response.Returns(responseBase);
-
-            ResultExecutingContext context = new ResultExecutingContext
-            {
-                HttpContext = contextBase
-            };
-
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
             filter.OnResultExecuting(context);

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -52,6 +52,7 @@ namespace DDDEastAnglia.Tests.Filters
         }
 
         [TestCase("X-Frame-Origins")]
+        [TestCase("X-XSS-Protection")]
         public void Security_Header_Is_Added(string headerName)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
@@ -64,6 +65,7 @@ namespace DDDEastAnglia.Tests.Filters
         }
 
         [TestCase("X-Frame-Origins", "SAMEORIGIN")]
+        [TestCase("X-XSS-Protection", "1; mode=block")]
         public void Security_Header_Is_Correct_Value(string headerName, string headerValue)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -1,12 +1,7 @@
-﻿using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Net;
+﻿using System.Collections.Specialized;
 using System.Web;
 using System.Web.Mvc;
-using DDDEastAnglia.App_Start.Filters;
-using DDDEastAnglia.Areas.Admin.Models;
-using DDDEastAnglia.Controllers;
-using DDDEastAnglia.DataAccess;
+using DDDEastAnglia.Filters;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -18,7 +13,7 @@ namespace DDDEastAnglia.Tests.Filters
         private HttpContextBase contextBase;
         private HttpResponseBase responseBase;
         private NameValueCollection headers;
-        private ResultExecutingContext context;
+        private ResultExecutedContext context;
 
         [SetUp]
         public void Setup()
@@ -29,7 +24,7 @@ namespace DDDEastAnglia.Tests.Filters
             responseBase.Headers.Returns(headers);
             contextBase.Response.Returns(responseBase);
 
-            context = new ResultExecutingContext
+            context = new ResultExecutedContext
             {
                 HttpContext = contextBase
             };
@@ -44,7 +39,7 @@ namespace DDDEastAnglia.Tests.Filters
 
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
-            filter.OnResultExecuting(context);
+            filter.OnResultExecuted(context);
 
             NameValueCollection filteredHeaders = responseBase.Headers;
             
@@ -59,7 +54,7 @@ namespace DDDEastAnglia.Tests.Filters
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
-            filter.OnResultExecuting(context);
+            filter.OnResultExecuted(context);
 
             NameValueCollection filteredHeaders = responseBase.Headers;
 
@@ -74,7 +69,7 @@ namespace DDDEastAnglia.Tests.Filters
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
 
-            filter.OnResultExecuting(context);
+            filter.OnResultExecuted(context);
 
             NameValueCollection filteredHeaders = responseBase.Headers;
 

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -30,22 +30,6 @@ namespace DDDEastAnglia.Tests.Filters
             };
         }
 
-        [TestCase("x-powered-by", "ASP.NET")]
-        [TestCase("x-aspnet-version", "4.0.30319")]
-        [TestCase("x-aspnetmvc-version", "4.0")]
-        public void ASPNET_Header_Is_Removed(string headerName, string headerValue)
-        {
-            headers.Add(headerName,headerValue);
-
-            SecurityHeadersFilter filter = new SecurityHeadersFilter();
-
-            filter.OnResultExecuted(context);
-
-            NameValueCollection filteredHeaders = responseBase.Headers;
-            
-            Assert.That(filteredHeaders[headerName], Is.Null);
-        }
-
         [TestCase("X-Frame-Origins")]
         [TestCase("X-XSS-Protection")]
         [TestCase("X-Content-Type-Options")]

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -53,6 +53,7 @@ namespace DDDEastAnglia.Tests.Filters
 
         [TestCase("X-Frame-Origins")]
         [TestCase("X-XSS-Protection")]
+        [TestCase("X-Content-Type-Options")]
         public void Security_Header_Is_Added(string headerName)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();
@@ -66,6 +67,7 @@ namespace DDDEastAnglia.Tests.Filters
 
         [TestCase("X-Frame-Origins", "SAMEORIGIN")]
         [TestCase("X-XSS-Protection", "1; mode=block")]
+        [TestCase("X-Content-Type-Options", "nosniff")]
         public void Security_Header_Is_Correct_Value(string headerName, string headerValue)
         {
             SecurityHeadersFilter filter = new SecurityHeadersFilter();

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Net;
+using System.Web;
+using System.Web.Mvc;
+using DDDEastAnglia.App_Start.Filters;
+using DDDEastAnglia.Areas.Admin.Models;
+using DDDEastAnglia.Controllers;
+using DDDEastAnglia.DataAccess;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Filters
+{
+
+    [TestFixture]
+    public class SecurityHeadersFilterTests
+    {
+        [Test]
+        public void XPoweredBy_Header_Is_Removed()
+        {
+            HttpContextBase contextBase = Substitute.For<HttpContextBase>();
+            HttpResponseBase responseBase = Substitute.For<HttpResponseBase>();
+            NameValueCollection headers = new NameValueCollection {{"X-Powered-By", "ASP.NET"}};
+            responseBase.Headers.Returns(headers);
+            contextBase.Response.Returns(responseBase);
+
+            ResultExecutingContext context = new ResultExecutingContext
+            {
+                HttpContext = contextBase
+            };
+
+            SecurityHeadersFilter filter = new SecurityHeadersFilter();
+
+            filter.OnResultExecuting(context);
+
+            NameValueCollection filteredHeaders = responseBase.Headers;
+            
+            Assert.That(filteredHeaders["X-Powered-By"], Is.Null);
+        }
+    }
+}

--- a/DDDEastAnglia/App_Start/FilterConfig.cs
+++ b/DDDEastAnglia/App_Start/FilterConfig.cs
@@ -11,6 +11,8 @@ namespace DDDEastAnglia
 
             FilterProviders.Providers.Add(new PreviewFilterProvider());
             FilterProviders.Providers.Add(new ClosedFilterProvider());
+
+            filters.Add(new SecurityHeadersFilter());
         }
     }
 }

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -1,18 +1,13 @@
-﻿using System;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
+using System.Linq;
 using System.Web;
 using System.Web.Mvc;
 
-namespace DDDEastAnglia.App_Start.Filters
+namespace DDDEastAnglia.Filters
 {
     public class SecurityHeadersFilter : IResultFilter
     {
         public void OnResultExecuted(ResultExecutedContext filterContext)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void OnResultExecuting(ResultExecutingContext filterContext)
         {
             HttpContextBase contextBase = filterContext.HttpContext;
             HttpResponseBase responseBase = contextBase.Response;
@@ -23,12 +18,20 @@ namespace DDDEastAnglia.App_Start.Filters
             AddSecurityHeaders(headers);
         }
 
-        private static void AddSecurityHeaders(NameValueCollection headers)
+        private void AddSecurityHeaders(NameValueCollection headers)
         {
-            headers.Add("X-Frame-Origins", "SAMEORIGIN");
-            headers.Add("X-XSS-Protection", "1; mode=block");
-            headers.Add("X-Content-Type-Options", "nosniff");
-            headers.Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            AddHeader(headers, "X-Frame-Origins", "SAMEORIGIN");
+            AddHeader(headers, "X-XSS-Protection", "1; mode=block");
+            AddHeader(headers, "X-Content-Type-Options", "nosniff");
+            AddHeader(headers, "Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        }
+
+        private void AddHeader(NameValueCollection headers, string headerName, string headerValue)
+        {
+            if (!headers.AllKeys.Contains(headerName))
+            {
+                headers.Add(headerName, headerValue);
+            }
         }
 
         private void RemoveASPNETHeaders(NameValueCollection headers)
@@ -36,6 +39,10 @@ namespace DDDEastAnglia.App_Start.Filters
             headers.Remove("x-powered-by");
             headers.Remove("x-aspnet-version");
             headers.Remove("x-aspnetmvc-version");
+        }
+
+        public void OnResultExecuting(ResultExecutingContext filterContext)
+        {
         }
     }
 }

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -17,7 +17,7 @@ namespace DDDEastAnglia.App_Start.Filters
             HttpContextBase contextBase = filterContext.HttpContext;
             HttpResponseBase responseBase = contextBase.Response;
             NameValueCollection headers = responseBase.Headers;
-            headers.Remove("X-Powered-By");
+            headers.Remove("x-powered-by");
             headers.Remove("x-aspnet-version");
             headers.Remove("x-aspnetmvc-version");
         }

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -23,6 +23,7 @@ namespace DDDEastAnglia.App_Start.Filters
             headers.Add("X-Frame-Origins", "SAMEORIGIN");
             headers.Add("X-XSS-Protection", "1; mode=block");
             headers.Add("X-Content-Type-Options","nosniff");
+            headers.Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
         }
 
         private void RemoveASPNETHeaders(NameValueCollection headers)

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -17,6 +17,12 @@ namespace DDDEastAnglia.App_Start.Filters
             HttpContextBase contextBase = filterContext.HttpContext;
             HttpResponseBase responseBase = contextBase.Response;
             NameValueCollection headers = responseBase.Headers;
+
+            RemoveASPNETHeaders(headers);
+        }
+
+        private void RemoveASPNETHeaders(NameValueCollection headers)
+        {
             headers.Remove("x-powered-by");
             headers.Remove("x-aspnet-version");
             headers.Remove("x-aspnetmvc-version");

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -13,8 +13,6 @@ namespace DDDEastAnglia.Filters
             HttpResponseBase responseBase = contextBase.Response;
             NameValueCollection headers = responseBase.Headers;
 
-            RemoveASPNETHeaders(headers);
-
             AddSecurityHeaders(headers);
         }
 
@@ -32,13 +30,6 @@ namespace DDDEastAnglia.Filters
             {
                 headers.Add(headerName, headerValue);
             }
-        }
-
-        private void RemoveASPNETHeaders(NameValueCollection headers)
-        {
-            headers.Remove("x-powered-by");
-            headers.Remove("x-aspnet-version");
-            headers.Remove("x-aspnetmvc-version");
         }
 
         public void OnResultExecuting(ResultExecutingContext filterContext)

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -20,9 +20,14 @@ namespace DDDEastAnglia.App_Start.Filters
 
             RemoveASPNETHeaders(headers);
 
+            AddSecurityHeaders(headers);
+        }
+
+        private static void AddSecurityHeaders(NameValueCollection headers)
+        {
             headers.Add("X-Frame-Origins", "SAMEORIGIN");
             headers.Add("X-XSS-Protection", "1; mode=block");
-            headers.Add("X-Content-Type-Options","nosniff");
+            headers.Add("X-Content-Type-Options", "nosniff");
             headers.Add("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
         }
 

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Web;
+using System.Web.Mvc;
+
+namespace DDDEastAnglia.App_Start.Filters
+{
+    public class SecurityHeadersFilter : IResultFilter
+    {
+        public void OnResultExecuted(ResultExecutedContext filterContext)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnResultExecuting(ResultExecutingContext filterContext)
+        {
+            HttpContextBase contextBase = filterContext.HttpContext;
+            HttpResponseBase responseBase = contextBase.Response;
+            NameValueCollection headers = responseBase.Headers;
+            headers.Remove("X-Powered-By");
+        }
+    }
+}

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -19,6 +19,8 @@ namespace DDDEastAnglia.App_Start.Filters
             NameValueCollection headers = responseBase.Headers;
 
             RemoveASPNETHeaders(headers);
+
+            headers.Add("X-Frame-Origins", "SAMEORIGIN");
         }
 
         private void RemoveASPNETHeaders(NameValueCollection headers)

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -18,6 +18,8 @@ namespace DDDEastAnglia.App_Start.Filters
             HttpResponseBase responseBase = contextBase.Response;
             NameValueCollection headers = responseBase.Headers;
             headers.Remove("X-Powered-By");
+            headers.Remove("x-aspnet-version");
+            headers.Remove("x-aspnetmvc-version");
         }
     }
 }

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -22,6 +22,7 @@ namespace DDDEastAnglia.App_Start.Filters
 
             headers.Add("X-Frame-Origins", "SAMEORIGIN");
             headers.Add("X-XSS-Protection", "1; mode=block");
+            headers.Add("X-Content-Type-Options","nosniff");
         }
 
         private void RemoveASPNETHeaders(NameValueCollection headers)

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -21,6 +21,7 @@ namespace DDDEastAnglia.App_Start.Filters
             RemoveASPNETHeaders(headers);
 
             headers.Add("X-Frame-Origins", "SAMEORIGIN");
+            headers.Add("X-XSS-Protection", "1; mode=block");
         }
 
         private void RemoveASPNETHeaders(NameValueCollection headers)

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -214,6 +214,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="App_Start\Filters\SecurityHeadersFilter.cs" />
     <Compile Include="Areas\Admin\Controllers\SpeakerController.cs" />
     <Compile Include="App_Start\Filters\AllowedWhenConferenceIsInPreviewAttribute.cs" />
     <Compile Include="App_Start\Filters\AllowedWhenConferenceIsClosedAttribute.cs" />

--- a/DDDEastAnglia/Global.asax.cs
+++ b/DDDEastAnglia/Global.asax.cs
@@ -22,6 +22,8 @@ namespace DDDEastAnglia
             AuthConfig.RegisterAuth();
 
             InitialiseDatabase();
+
+            MvcHandler.DisableMvcResponseHeader = true;
         }
 
         private static void InitialiseDatabase()

--- a/DDDEastAnglia/Web.config
+++ b/DDDEastAnglia/Web.config
@@ -74,7 +74,11 @@
             <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="14.00:00:00" />
         </staticContent>
 
-        
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By" />
+        </customHeaders>
+      </httpProtocol>
     </system.webServer>
 
     <runtime>

--- a/DDDEastAnglia/Web.config
+++ b/DDDEastAnglia/Web.config
@@ -24,7 +24,7 @@
 
     <system.web>
         <customErrors mode="RemoteOnly" />
-        <httpRuntime targetFramework="4.5.1" />
+        <httpRuntime targetFramework="4.5.1" enableVersionHeader="false" />
         <compilation debug="true" targetFramework="4.5.1" />
 
         <authentication mode="Forms">
@@ -73,6 +73,8 @@
             <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
             <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="14.00:00:00" />
         </staticContent>
+
+        
     </system.webServer>
 
     <runtime>


### PR DESCRIPTION
Looking at our [SecurityHeaders report](https://securityheaders.com/?q=dddeastanglia.com&hide=on&followRedirects=on) we're currently getting an F - this PR is to add a number of the headers we're currently missing and also remove the ASP.NET version headers. Once this is merged I'll add issues for Content Security Policy/Feature Policy/Referer Policy.