### PR TITLE
Only send the STS header over https

### DIFF
--- a/DDDEastAnglia.Tests/Controllers/HomeControllerTests.cs
+++ b/DDDEastAnglia.Tests/Controllers/HomeControllerTests.cs
@@ -1,6 +1,9 @@
 ﻿using DDDEastAnglia.Controllers;
 using DDDEastAnglia.DataAccess;
+using DDDEastAnglia.Helpers.Agenda;
+using DDDEastAnglia.Helpers.Sessions;
 using DDDEastAnglia.Models;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace DDDEastAnglia.Tests.Controllers
@@ -102,7 +105,7 @@ namespace DDDEastAnglia.Tests.Controllers
         private HomeController CreateHomeController(IConferenceLoader conferenceLoader)
         {
             var sponsorModelQuery = new AllPublicSponsors(new InMemorySponsorRepository(), new DefaultSponsorSorter());
-            return new HomeController(conferenceLoader, sponsorModelQuery);
+            return new HomeController(conferenceLoader, sponsorModelQuery, new AgendaSessionsLoader(Substitute.For<ISessionLoader>(), Substitute.For<ISpeakerRepository>()));
         }
     }
 }

--- a/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
+++ b/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Admin\SessionControllerTests.cs" />
     <Compile Include="Admin\UserControllerTests.cs" />
     <Compile Include="DataAccess\DefaultSponsorSorterTests.cs" />
+    <Compile Include="Filters\SecurityHeadersFilterTests.cs" />
     <Compile Include="Helpers\ImageResizeExtensionsTests.cs" />
     <Compile Include="Sponsors\Query\Context.cs" />
     <Compile Include="Sponsors\Query\Sponsors_who_havent_paid_yet.cs" />

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Specialized;
+using System.Web;
+using System.Web.Mvc;
+using DDDEastAnglia.Filters;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Filters
+{
+    [TestFixture]
+    public class SecurityHeadersFilterTests
+    {
+        private HttpContextBase contextBase;
+        private HttpResponseBase responseBase;
+        private NameValueCollection headers;
+        private ResultExecutedContext context;
+
+        [SetUp]
+        public void Setup()
+        {
+            contextBase = Substitute.For<HttpContextBase>();
+            responseBase = Substitute.For<HttpResponseBase>();
+            headers = new NameValueCollection();
+            responseBase.Headers.Returns(headers);
+            contextBase.Response.Returns(responseBase);
+
+            context = new ResultExecutedContext
+            {
+                HttpContext = contextBase
+            };
+        }
+
+        [TestCase("X-Frame-Origins")]
+        [TestCase("X-XSS-Protection")]
+        [TestCase("X-Content-Type-Options")]
+        [TestCase("Strict-Transport-Security")]
+        public void Security_Header_Is_Added(string headerName)
+        {
+            SecurityHeadersFilter filter = new SecurityHeadersFilter();
+
+            filter.OnResultExecuted(context);
+
+            NameValueCollection filteredHeaders = responseBase.Headers;
+
+            Assert.That(filteredHeaders[headerName], Is.Not.Null);
+        }
+
+        [TestCase("X-Frame-Origins", "SAMEORIGIN")]
+        [TestCase("X-XSS-Protection", "1; mode=block")]
+        [TestCase("X-Content-Type-Options", "nosniff")]
+        [TestCase("Strict-Transport-Security", "max-age=31536000; includeSubDomains")]
+        public void Security_Header_Is_Correct_Value(string headerName, string headerValue)
+        {
+            SecurityHeadersFilter filter = new SecurityHeadersFilter();
+
+            filter.OnResultExecuted(context);
+
+            NameValueCollection filteredHeaders = responseBase.Headers;
+
+            Assert.That(filteredHeaders[headerName], Is.EqualTo(headerValue));
+        }
+    }
+}

--- a/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
+++ b/DDDEastAnglia.Tests/Filters/SecurityHeadersFilterTests.cs
@@ -30,7 +30,7 @@ namespace DDDEastAnglia.Tests.Filters
             };
         }
 
-        [TestCase("X-Frame-Origins")]
+        [TestCase("X-Frame-Options")]
         [TestCase("X-XSS-Protection")]
         [TestCase("X-Content-Type-Options")]
         [TestCase("Strict-Transport-Security")]
@@ -45,7 +45,7 @@ namespace DDDEastAnglia.Tests.Filters
             Assert.That(filteredHeaders[headerName], Is.Not.Null);
         }
 
-        [TestCase("X-Frame-Origins", "SAMEORIGIN")]
+        [TestCase("X-Frame-Options", "SAMEORIGIN")]
         [TestCase("X-XSS-Protection", "1; mode=block")]
         [TestCase("X-Content-Type-Options", "nosniff")]
         [TestCase("Strict-Transport-Security", "max-age=31536000; includeSubDomains")]

--- a/DDDEastAnglia/App_Start/FilterConfig.cs
+++ b/DDDEastAnglia/App_Start/FilterConfig.cs
@@ -11,6 +11,8 @@ namespace DDDEastAnglia
 
             FilterProviders.Providers.Add(new PreviewFilterProvider());
             FilterProviders.Providers.Add(new ClosedFilterProvider());
+
+            filters.Add(new SecurityHeadersFilter());
         }
     }
 }

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Specialized;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace DDDEastAnglia.Filters
+{
+    public class SecurityHeadersFilter : IResultFilter
+    {
+        public void OnResultExecuted(ResultExecutedContext filterContext)
+        {
+            HttpContextBase contextBase = filterContext.HttpContext;
+            HttpResponseBase responseBase = contextBase.Response;
+            NameValueCollection headers = responseBase.Headers;
+
+            AddSecurityHeaders(headers);
+        }
+
+        private void AddSecurityHeaders(NameValueCollection headers)
+        {
+            AddHeader(headers, "X-Frame-Origins", "SAMEORIGIN");
+            AddHeader(headers, "X-XSS-Protection", "1; mode=block");
+            AddHeader(headers, "X-Content-Type-Options", "nosniff");
+            AddHeader(headers, "Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        }
+
+        private void AddHeader(NameValueCollection headers, string headerName, string headerValue)
+        {
+            if (!headers.AllKeys.Contains(headerName))
+            {
+                headers.Add(headerName, headerValue);
+            }
+        }
+
+        public void OnResultExecuting(ResultExecutingContext filterContext)
+        {
+        }
+    }
+}

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -10,18 +10,22 @@ namespace DDDEastAnglia.Filters
         public void OnResultExecuted(ResultExecutedContext filterContext)
         {
             HttpContextBase contextBase = filterContext.HttpContext;
+            HttpRequestBase requestBase = contextBase.Request;
             HttpResponseBase responseBase = contextBase.Response;
             NameValueCollection headers = responseBase.Headers;
 
-            AddSecurityHeaders(headers);
+            AddSecurityHeaders(headers, requestBase.IsSecureConnection);
         }
 
-        private void AddSecurityHeaders(NameValueCollection headers)
+        private void AddSecurityHeaders(NameValueCollection headers, bool isSecure)
         {
             AddHeader(headers, "X-Frame-Options", "SAMEORIGIN");
             AddHeader(headers, "X-XSS-Protection", "1; mode=block");
             AddHeader(headers, "X-Content-Type-Options", "nosniff");
-            AddHeader(headers, "Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            if (isSecure)
+            {
+                AddHeader(headers, "Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+            }
         }
 
         private void AddHeader(NameValueCollection headers, string headerName, string headerValue)

--- a/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
+++ b/DDDEastAnglia/App_Start/Filters/SecurityHeadersFilter.cs
@@ -18,7 +18,7 @@ namespace DDDEastAnglia.Filters
 
         private void AddSecurityHeaders(NameValueCollection headers)
         {
-            AddHeader(headers, "X-Frame-Origins", "SAMEORIGIN");
+            AddHeader(headers, "X-Frame-Options", "SAMEORIGIN");
             AddHeader(headers, "X-XSS-Protection", "1; mode=block");
             AddHeader(headers, "X-Content-Type-Options", "nosniff");
             AddHeader(headers, "Strict-Transport-Security", "max-age=31536000; includeSubDomains");

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -214,6 +214,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="App_Start\Filters\SecurityHeadersFilter.cs" />
     <Compile Include="Areas\Admin\Controllers\SpeakerController.cs" />
     <Compile Include="App_Start\Filters\AllowedWhenConferenceIsInPreviewAttribute.cs" />
     <Compile Include="App_Start\Filters\AllowedWhenConferenceIsClosedAttribute.cs" />

--- a/DDDEastAnglia/Global.asax.cs
+++ b/DDDEastAnglia/Global.asax.cs
@@ -22,6 +22,8 @@ namespace DDDEastAnglia
             AuthConfig.RegisterAuth();
 
             InitialiseDatabase();
+
+            MvcHandler.DisableMvcResponseHeader = true;
         }
 
         private static void InitialiseDatabase()

--- a/DDDEastAnglia/Views/Home/About.cshtml
+++ b/DDDEastAnglia/Views/Home/About.cshtml
@@ -9,8 +9,8 @@
         <h2>About DDD East Anglia</h2>
 
         <p>
-            Developer! Developer! Developer! (DDD) East Anglia is the newest event in the popular series of
-            Developer Days events for the UK .NET Community that have run since May 2005. Although each DDD
+            Developer! Developer! Developer! (DDD) East Anglia is part of the popular series of
+            Developer Days events for the UK developer community that have run since May 2005. Although each DDD
             event has its own particular "flavour", they remain immensely popular and enjoyable, regularly
             attracting 200-300 attendees and often selling out within minutes.
         </p>
@@ -30,7 +30,7 @@
             <a href="#sessions">Sessions</a> are @HTMLExtensions.ActionLink(Html, "submitted", "Create", "Session", Model.ShowSessionSubmissionLink)
             by members of the community and selected by attendees. Microsoft speakers are generally not permitted
             to speak at DDD events, but the exceptions to this rule are Microsoft employees who are active members
-            of the UK .NET community. In short, these are sessions crafted <em>by</em> developers <em>for</em>
+            of the UK developer community. In short, these are sessions crafted <em>by</em> developers <em>for</em>
             developers, with no sales pitches allowed!
         </p>
 
@@ -44,7 +44,7 @@
         <h4 id="ddd-process">How is the agenda decided?</h4>
         <p>
             DDD events are unique in that <strong>the conference is made by its attendees</strong>.
-            <a href="#sessions">Sessions</a> are submitted by members of the UK .NET developer community
+            <a href="#sessions">Sessions</a> are submitted by members of the UK developer community
             (i.e. <em>you</em> can @HTMLExtensions.ActionLink(Html, "submit a session", "Create", "Session", Model.ShowSessionSubmissionLink)
             if you want to), and are voted on by prospective attendees (i.e. you) before registration opens. The
             organisers of DDD events use the results of the voting to determine which sessions are most popular,
@@ -70,7 +70,7 @@
 
         <h4 id="session-topics">What topics do you accept sessions on?</h4>
         <p>
-            Anything relevant to a .NET developer! Other DDD events have seen submissions on the Raspberry Pi and
+            Anything relevant to a modern developer! Other DDD events have seen submissions on the Raspberry Pi and
             Gadgeteer, Unit Testing and Test-Driven Development, NoSQL databases like RavenDB and Redis, JavaScript,
             mobile devices. &quot;Softer&quot; topics such as best practices, agile software development, and taking
             your side project to a prime time business, have also been presented.

--- a/DDDEastAnglia/Views/Home/Venue.cshtml
+++ b/DDDEastAnglia/Views/Home/Venue.cshtml
@@ -34,7 +34,7 @@
 
 <p>
     The venue is a <a href="https://goo.gl/maps/PZd3s8McSQx">short drive</a> from M11 junction 11.
-    There is no parking on site, but the <a href="https://goo.gl/maps/bEuEKmbutM22">Cambridge Leisure Park's multistorey car park</a> on Clifton Road is only a <a href="https://goo.gl/maps/BNQCQGFT6t22">few minutes walk</a> away.
+    There is no parking on site, but the <a href="https://goo.gl/maps/bEuEKmbutM22">Cambridge Leisure Park's multistorey car park</a> on Clifton Road is only a <a href="https://goo.gl/maps/BNQCQGFT6t22">few minutes walk</a> away. There is also <a href="https://en.parkopedia.co.uk/parking/locations/cb2_8pe_cambridge_cambridgeshire_england_united_kingdom_u120ghdc33w/?country=uk">on-street parking</a> near the college.
 </p>
 
 <p>

--- a/DDDEastAnglia/Web.config
+++ b/DDDEastAnglia/Web.config
@@ -24,7 +24,7 @@
 
     <system.web>
         <customErrors mode="RemoteOnly" />
-        <httpRuntime targetFramework="4.5.1" />
+        <httpRuntime targetFramework="4.5.1" enableVersionHeader="false" />
         <compilation debug="true" targetFramework="4.5.1" />
 
         <authentication mode="Forms">
@@ -73,6 +73,12 @@
             <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
             <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="14.00:00:00" />
         </staticContent>
+
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By" />
+        </customHeaders>
+      </httpProtocol>
     </system.webServer>
 
     <runtime>


### PR DESCRIPTION
To be technically correct, the Strict Transport Security header should only be sent over https. Sending it over http doesn't affect our rating on SecurityHeaders.com, but we want to follow the spec...