### PR TITLE
Add anonymous session submissions and voting

### DIFF
--- a/DDDEastAnglia.DatabaseMigrations/DDDEastAnglia.DatabaseMigrations.csproj
+++ b/DDDEastAnglia.DatabaseMigrations/DDDEastAnglia.DatabaseMigrations.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Migrations\0-InitialDatabase.cs" />
     <Compile Include="Migrations\2-AddTrackInformationToConferencesTable.cs" />
     <Compile Include="Migrations\3-AddSponsorsTable.cs" />
+    <Compile Include="Migrations\4-AddAnonymousSessionsSetting.cs" />
     <Compile Include="Migrator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/DDDEastAnglia.DatabaseMigrations/DDDEastAnglia.DatabaseMigrations.csproj
+++ b/DDDEastAnglia.DatabaseMigrations/DDDEastAnglia.DatabaseMigrations.csproj
@@ -48,16 +48,87 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FluentMigrator">
-      <HintPath>..\packages\FluentMigrator.1.1.2.1\lib\40\FluentMigrator.dll</HintPath>
+    <Reference Include="FluentMigrator, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.2.0.7\lib\net45\FluentMigrator.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentMigrator.Runner">
-      <HintPath>..\packages\FluentMigrator.Tools.1.1.2.1\tools\AnyCPU\40\FluentMigrator.Runner.dll</HintPath>
+    <Reference Include="FluentMigrator.Abstractions, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Abstractions.2.0.7\lib\net45\FluentMigrator.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Extensions.SqlAnywhere, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Extensions.SqlAnywhere.2.0.7\lib\net45\FluentMigrator.Extensions.SqlAnywhere.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Extensions.SqlServer, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Extensions.SqlServer.2.0.7\lib\net45\FluentMigrator.Extensions.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.2.0.7\lib\net45\FluentMigrator.Runner.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Core, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Core.2.0.7\lib\net45\FluentMigrator.Runner.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Db2, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Db2.2.0.7\lib\net45\FluentMigrator.Runner.Db2.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Firebird, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Firebird.2.0.7\lib\net45\FluentMigrator.Runner.Firebird.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Hana, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Hana.2.0.7\lib\net45\FluentMigrator.Runner.Hana.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Jet, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Jet.2.0.7\lib\net45\FluentMigrator.Runner.Jet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.MySql, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.MySql.2.0.7\lib\net45\FluentMigrator.Runner.MySql.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Oracle, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Oracle.2.0.7\lib\net45\FluentMigrator.Runner.Oracle.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Postgres, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Postgres.2.0.7\lib\net45\FluentMigrator.Runner.Postgres.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.Redshift, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.Redshift.2.0.7\lib\net45\FluentMigrator.Runner.Redshift.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.SqlAnywhere, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.SqlAnywhere.2.0.7\lib\net45\FluentMigrator.Runner.SqlAnywhere.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.SQLite, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.SQLite.2.0.7\lib\net45\FluentMigrator.Runner.SQLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.SqlServer, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.SqlServer.2.0.7\lib\net45\FluentMigrator.Runner.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner.SqlServerCe, Version=2.0.7.0, Culture=neutral, PublicKeyToken=aacfc7de5acabf05">
+      <HintPath>..\packages\FluentMigrator.Runner.SqlServerCe.2.0.7\lib\net45\FluentMigrator.Runner.SqlServerCe.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1\System.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91">
+      <HintPath>..\packages\Microsoft.SqlServer.Compact.4.0.8876.1\lib\net40\System.Data.SqlServerCe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/DDDEastAnglia.DatabaseMigrations/MigrationOptions.cs
+++ b/DDDEastAnglia.DatabaseMigrations/MigrationOptions.cs
@@ -5,7 +5,7 @@ namespace DDDEastAnglia.DatabaseMigrations
     public class MigrationOptions : IMigrationProcessorOptions
     {
         public bool PreviewOnly{get;set;}
-        public int Timeout{get;set;}
+        public int? Timeout{get;set;}
         public string ProviderSwitches{get;set;}
     }
 }

--- a/DDDEastAnglia.DatabaseMigrations/Migrations/4-AddAnonymousSessionsSetting.cs
+++ b/DDDEastAnglia.DatabaseMigrations/Migrations/4-AddAnonymousSessionsSetting.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentMigrator;
+
+namespace DDDEastAnglia.DatabaseMigrations.Migrations
+{
+    [Migration(20190523)]
+    public class AddAnonymousSessionsSetting : ForwardOnlyMigration
+    {
+        public override void Up()
+        {
+            Alter.Table("Conferences")
+                .AddColumn("AnonymousSessions").AsBoolean().Nullable();
+        }
+    }
+}

--- a/DDDEastAnglia.DatabaseMigrations/Migrations/4-AddAnonymousSessionsSetting.cs
+++ b/DDDEastAnglia.DatabaseMigrations/Migrations/4-AddAnonymousSessionsSetting.cs
@@ -1,4 +1,4 @@
-using FluentMigrator;
+﻿using FluentMigrator;
 
 namespace DDDEastAnglia.DatabaseMigrations.Migrations
 {
@@ -8,7 +8,7 @@ namespace DDDEastAnglia.DatabaseMigrations.Migrations
         public override void Up()
         {
             Alter.Table("Conferences")
-                .AddColumn("AnonymousSessions").AsBoolean().Nullable();
+                .AddColumn("AnonymousSessions").AsBoolean().NotNullable().SetExistingRowsTo(false);
         }
 
         public override void Down()

--- a/DDDEastAnglia.DatabaseMigrations/Migrations/4-AddAnonymousSessionsSetting.cs
+++ b/DDDEastAnglia.DatabaseMigrations/Migrations/4-AddAnonymousSessionsSetting.cs
@@ -1,19 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentMigrator;
 
 namespace DDDEastAnglia.DatabaseMigrations.Migrations
 {
     [Migration(20190523)]
-    public class AddAnonymousSessionsSetting : ForwardOnlyMigration
+    public class AddAnonymousSessionsSetting : Migration
     {
         public override void Up()
         {
             Alter.Table("Conferences")
                 .AddColumn("AnonymousSessions").AsBoolean().Nullable();
+        }
+
+        public override void Down()
+        {
+            Delete.Column("AnonymousSessions")
+                .FromTable("Conferences");
         }
     }
 }

--- a/DDDEastAnglia.DatabaseMigrations/packages.config
+++ b/DDDEastAnglia.DatabaseMigrations/packages.config
@@ -1,5 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentMigrator" version="1.1.2.1" targetFramework="net45" />
-  <package id="FluentMigrator.Tools" version="1.1.2.1" targetFramework="net451" />
+  <package id="FluentMigrator" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Abstractions" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Extensions.SqlAnywhere" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Extensions.SqlServer" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Core" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Db2" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Firebird" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Hana" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Jet" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.MySql" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Oracle" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Postgres" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.Redshift" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.SqlAnywhere" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.SQLite" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.SqlServer" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Runner.SqlServerCe" version="2.0.7" targetFramework="net451" />
+  <package id="FluentMigrator.Tools" version="2.0.7" targetFramework="net451" />
+  <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net451" />
 </packages>

--- a/DDDEastAnglia.Tests/Controllers/NavigationBarControllerShould.cs
+++ b/DDDEastAnglia.Tests/Controllers/NavigationBarControllerShould.cs
@@ -88,8 +88,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var adminLink = FindLink(result, "Admin");
-            Assert.IsFalse(adminLink.IsVisible);
+            var link = FindLink(result, "Admin");
+            Assert.IsFalse(link.IsVisible);
         }
 
         [Test]
@@ -99,8 +99,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var adminLink = FindLink(result, "Admin");
-            Assert.IsTrue(adminLink.IsVisible);
+            var link = FindLink(result, "Admin");
+            Assert.IsTrue(link.IsVisible);
         }
 
         [Test]
@@ -110,8 +110,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var registrationLink = FindLink(result, "Register");
-            Assert.IsFalse(registrationLink.IsVisible);
+            var link = FindLink(result, "Register");
+            Assert.IsFalse(link.IsVisible);
         }
 
         [Test]
@@ -121,8 +121,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var registrationLink = FindLink(result, "Register");
-            Assert.IsTrue(registrationLink.IsVisible);
+            var link = FindLink(result, "Register");
+            Assert.IsTrue(link.IsVisible);
         }
 
         [Test]
@@ -132,8 +132,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var registrationLink = FindLink(result, "Accommodation");
-            Assert.IsFalse(registrationLink.IsVisible);
+            var link = FindLink(result, "Accommodation");
+            Assert.IsFalse(link.IsVisible);
         }
 
         [Test]
@@ -143,8 +143,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var registrationLink = FindLink(result, "Accommodation");
-            Assert.IsTrue(registrationLink.IsVisible);
+            var link = FindLink(result, "Accommodation");
+            Assert.IsTrue(link.IsVisible);
         }
 
         [Test]
@@ -154,74 +154,8 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var agendaLink = FindLink(result, "Agenda");
-            Assert.IsFalse(agendaLink.IsVisible);
-        }
-
-        [Test]
-        public void SetTheSpeakersLinkToVisible_WhenTheEventReportsThatSessionVotingIsOpen()
-        {
-            var controller = CreateController(conference => conference.CanVote().Returns(true));
-
-            var result = controller.RenderMenu();
-
-            var agendaLink = FindLink(result, "Speakers");
-            Assert.IsTrue(agendaLink.IsVisible);
-        }
-
-        [Test]
-        public void SetTheSpeakersLinkToVisible_WhenTheEventReportsThatSessionSubmissionIsOpen()
-        {
-            var controller = CreateController(conference => conference.CanSubmit().Returns(true));
-
-            var result = controller.RenderMenu();
-
-            var agendaLink = FindLink(result, "Speakers");
-            Assert.IsTrue(agendaLink.IsVisible);
-        }
-
-        [Test]
-        public void SetTheSpeakersLinkToNotVisible_WhenTheEventReportsThatTheAgendaIsPublished()
-        {
-            var controller = CreateController(conference => conference.CanPublishAgenda().Returns(true));
-
-            var result = controller.RenderMenu();
-
-            var agendaLink = FindLink(result, "Speakers");
-            Assert.IsFalse(agendaLink.IsVisible);
-        }
-
-        [Test]
-        public void SetTheSessionsLinkToVisible_WhenTheEventReportsThatSessionSubmissionIsOpen()
-        {
-            var controller = CreateController(conference => conference.CanSubmit().Returns(true));
-
-            var result = controller.RenderMenu();
-
-            var agendaLink = FindLink(result, "Sessions");
-            Assert.IsTrue(agendaLink.IsVisible);
-        }
-
-        [Test]
-        public void SetTheSessionsLinkToVisible_WhenTheEventReportsThatSessionVotingIsOpen()
-        {
-            var controller = CreateController(conference => conference.CanVote().Returns(true));
-
-            var result = controller.RenderMenu();
-
-            var agendaLink = FindLink(result, "Sessions");
-            Assert.IsTrue(agendaLink.IsVisible);
-        }
-
-        [Test]
-        public void SetTheSessionsLinkToNotVisible_WhenTheEventReportsThatTheAgendaIsPublished()
-        {
-            var controller = CreateController(conference => conference.CanPublishAgenda().Returns(true));
-
-            var result = controller.RenderMenu();
-
-            var agendaLink = FindLink(result, "Sessions");
-            Assert.IsFalse(agendaLink.IsVisible);
+            var link = FindLink(result, "Agenda");
+            Assert.IsFalse(link.IsVisible);
         }
 
         [Test]
@@ -231,8 +165,52 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var result = controller.RenderMenu();
 
-            var agendaLink = FindLink(result, "Agenda");
-            Assert.IsTrue(agendaLink.IsVisible);
+            var link = FindLink(result, "Agenda");
+            Assert.IsTrue(link.IsVisible);
+        }
+
+        [Test]
+        public void SetTheSpeakersLinkToVisible_WhenTheEventReportsThatSpeakersCanBeShown()
+        {
+            var controller = CreateController(conference => conference.CanShowSpeakers().Returns(true));
+
+            var result = controller.RenderMenu();
+
+            var link = FindLink(result, "Speakers");
+            Assert.IsTrue(link.IsVisible);
+        }
+
+        [Test]
+        public void SetTheSpeakersLinkToVisible_WhenTheEventReportsThatSpeakersCannotBeShown()
+        {
+            var controller = CreateController(conference => conference.CanShowSpeakers().Returns(false));
+
+            var result = controller.RenderMenu();
+
+            var link = FindLink(result, "Speakers");
+            Assert.IsFalse(link.IsVisible);
+        }
+
+        [Test]
+        public void SetTheSessionsLinkToVisible_WhenTheEventReportsThatSessionsCanBeShown()
+        {
+            var controller = CreateController(conference => conference.CanShowSessions().Returns(true));
+
+            var result = controller.RenderMenu();
+
+            var link = FindLink(result, "Sessions");
+            Assert.IsTrue(link.IsVisible);
+        }
+
+        [Test]
+        public void SetTheSessionsLinkToNotVisible_WhenTheEventReportsThatSessionsCannotBeShown()
+        {
+            var controller = CreateController(conference => conference.CanShowSessions().Returns(false));
+
+            var result = controller.RenderMenu();
+
+            var link = FindLink(result, "Sessions");
+            Assert.IsFalse(link.IsVisible);
         }
 
         private NavigationMenuLinkViewModel FindLink(ActionResult result, string linkText)
@@ -243,9 +221,9 @@ namespace DDDEastAnglia.Tests.Controllers
             return link;
         }
 
-        private NavigationBarController CreateController(Action<IConference> conferenceSetupCallback = null, 
-                                                            string[] userRoles = null, 
-                                                            string currentControllerName = "some controller", 
+        private NavigationBarController CreateController(Action<IConference> conferenceSetupCallback = null,
+                                                            string[] userRoles = null,
+                                                            string currentControllerName = "some controller",
                                                             string currentActionName = "some action")
         {
             var conference = Substitute.For<IConference>();
@@ -259,7 +237,7 @@ namespace DDDEastAnglia.Tests.Controllers
 
             var conferenceLoader = Substitute.For<IConferenceLoader>();
             conferenceLoader.LoadConference().Returns(conference);
-            
+
             var routeData = new RouteData();
             routeData.Values.Add("controller", currentControllerName);
             routeData.Values.Add("action", currentActionName);

--- a/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
+++ b/DDDEastAnglia.Tests/DDDEastAnglia.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Admin\SessionControllerTests.cs" />
     <Compile Include="Admin\UserControllerTests.cs" />
     <Compile Include="DataAccess\DefaultSponsorSorterTests.cs" />
+    <Compile Include="Domain\Conferences\Given_Anonymous_Submissions_IsEnabled_The_Conference_Should.cs" />
     <Compile Include="Filters\SecurityHeadersFilterTests.cs" />
     <Compile Include="Helpers\ImageResizeExtensionsTests.cs" />
     <Compile Include="Sponsors\Query\Context.cs" />

--- a/DDDEastAnglia.Tests/Domain/Conferences/Given_Anonymous_Submissions_IsEnabled_The_Conference_Should.cs
+++ b/DDDEastAnglia.Tests/Domain/Conferences/Given_Anonymous_Submissions_IsEnabled_The_Conference_Should.cs
@@ -1,0 +1,16 @@
+using DDDEastAnglia.Domain;
+using NUnit.Framework;
+
+namespace DDDEastAnglia.Tests.Domain.Conferences
+{
+    [TestFixture]
+    public sealed class Given_Anonymous_Submissions_IsEnabled_The_Conference_Should
+    {
+        [Test]
+        public void NotAllowSpeakersToBeShown()
+        {
+            var conference = new Conference(0, "", "", anonymousSessions: true);
+            Assert.IsFalse(conference.CanShowSpeakers());
+        }
+    }
+}

--- a/DDDEastAnglia/App_Code/HTMLExtensions.cs
+++ b/DDDEastAnglia/App_Code/HTMLExtensions.cs
@@ -27,22 +27,6 @@ public static class HTMLExtensions
         return new MvcHtmlString(@"<strong class=""dddea"">DDD East Anglia</strong>");
     }
 
-    public static MvcHtmlString TweetButton(this HtmlHelper htmlHelper, string tweetText, Uri url = null)
-    {
-        var encodedTweetText = Uri.EscapeDataString(tweetText); // escape anything URI-unfriendly in the tweet body (e.g., hash-tags)
-
-        if (url != null)
-        {
-            encodedTweetText += " " + Uri.EscapeUriString(url.ToString()); // escape the URL
-        }
-
-        encodedTweetText = htmlHelper.Encode(encodedTweetText); // HTML-encode the resulting string
-        return new MvcHtmlString(
-            string.Format(
-                @"<a href=""https://twitter.com/intent/tweet?text={0}"" class=""btn btn-mini"" target=""_blank""><i class=""icon-twitter""></i> Tweet</a>",
-                encodedTweetText));
-    }
-
     public static MvcHtmlString ActionLink(this HtmlHelper htmlHelper, string linkText, string actionName, string controllerName, bool displayCondition)
     {
         return displayCondition ? htmlHelper.ActionLink(linkText, actionName, controllerName) : new MvcHtmlString(linkText);

--- a/DDDEastAnglia/Content/Site.css
+++ b/DDDEastAnglia/Content/Site.css
@@ -88,11 +88,6 @@ footer span {
     padding-bottom: 10px;
 }
 
-.tweet-session {
-    margin-top: 10px;
-    margin-bottom: 10px;
-}
-
 .inline-large-icon {
     display: inline-block;
     width: 20px;
@@ -161,8 +156,7 @@ footer span {
     border-bottom: 0;
 }
 
-#delete-session .session-actions,
-#delete-session .session-tweet {
+#delete-session .session-actions {
     display: none;
 }
 

--- a/DDDEastAnglia/Controllers/NavigationBarController.cs
+++ b/DDDEastAnglia/Controllers/NavigationBarController.cs
@@ -39,13 +39,21 @@ namespace DDDEastAnglia.Controllers
         public ActionResult RenderMenu()
         {
             var conference = conferenceLoader.LoadConference();
-            bool showLinksForSubmittedSessions = !conference.CanPublishAgenda() && (conference.CanSubmit() || conference.CanVote());
+            bool showLinksForSubmittedSessions;
+            if (conference.AnonymousSessions())
+            {
+                showLinksForSubmittedSessions = conference.CanShowSessions();
+            }
+            else
+            {
+                showLinksForSubmittedSessions = !conference.CanPublishAgenda() && (conference.CanSubmit() || conference.CanVote());
+            }
 
             var links = new List<NavigationMenuLinkViewModel>
                 {
                     CreateLink("Home", "Home", "Index"), 
                     CreateLink("Sessions", "Session", "Index", () => showLinksForSubmittedSessions),
-                    CreateLink("Speakers", "Speaker", "Index", () => showLinksForSubmittedSessions),
+                    CreateLink("Speakers", "Speaker", "Index", () => conference.CanShowSpeakers()),
                     CreateLink("Agenda", "Home", "Agenda", conference.CanPublishAgenda),
                     CreateLink("Register", "Home", "Register", conference.CanRegister),
                     CreateLink("New to DDD?", "Home", "About"),

--- a/DDDEastAnglia/Controllers/NavigationBarController.cs
+++ b/DDDEastAnglia/Controllers/NavigationBarController.cs
@@ -42,7 +42,11 @@ namespace DDDEastAnglia.Controllers
             var links = new List<NavigationMenuLinkViewModel>
                 {
                     CreateLink("Home", "Home", "Index"),
-                    CreateLink("Sessions", "Session", "Index", conference.CanShowSessions),
+                    CreateLink("Sessions", "Session", "Index", () =>
+                    {
+                        var canShowSessions = conference.CanShowSessions();
+                        return canShowSessions;
+                    }),
                     CreateLink("Speakers", "Speaker", "Index", conference.CanShowSpeakers),
                     CreateLink("Agenda", "Home", "Agenda", conference.CanPublishAgenda),
                     CreateLink("Register", "Home", "Register", conference.CanRegister),

--- a/DDDEastAnglia/Controllers/NavigationBarController.cs
+++ b/DDDEastAnglia/Controllers/NavigationBarController.cs
@@ -39,21 +39,11 @@ namespace DDDEastAnglia.Controllers
         public ActionResult RenderMenu()
         {
             var conference = conferenceLoader.LoadConference();
-            bool showLinksForSubmittedSessions;
-            if (conference.AnonymousSessions())
-            {
-                showLinksForSubmittedSessions = conference.CanShowSessions();
-            }
-            else
-            {
-                showLinksForSubmittedSessions = !conference.CanPublishAgenda() && (conference.CanSubmit() || conference.CanVote());
-            }
-
             var links = new List<NavigationMenuLinkViewModel>
                 {
-                    CreateLink("Home", "Home", "Index"), 
-                    CreateLink("Sessions", "Session", "Index", () => showLinksForSubmittedSessions),
-                    CreateLink("Speakers", "Speaker", "Index", () => conference.CanShowSpeakers()),
+                    CreateLink("Home", "Home", "Index"),
+                    CreateLink("Sessions", "Session", "Index", conference.CanShowSessions),
+                    CreateLink("Speakers", "Speaker", "Index", conference.CanShowSpeakers),
                     CreateLink("Agenda", "Home", "Agenda", conference.CanPublishAgenda),
                     CreateLink("Register", "Home", "Register", conference.CanRegister),
                     CreateLink("New to DDD?", "Home", "About"),
@@ -70,7 +60,7 @@ namespace DDDEastAnglia.Controllers
             return PartialView(model);
         }
 
-        private NavigationMenuLinkViewModel CreateLink(string linkText, string controllerName, string actionName, 
+        private NavigationMenuLinkViewModel CreateLink(string linkText, string controllerName, string actionName,
                                                         Func<bool> isVisible = null, object routeValues = null)
         {
             var urlHelper = urlHelperFactory.Create(ControllerContext.RequestContext);

--- a/DDDEastAnglia/Controllers/SessionController.cs
+++ b/DDDEastAnglia/Controllers/SessionController.cs
@@ -40,8 +40,7 @@ namespace DDDEastAnglia.Controllers
             var sessions = sessionRepository.GetAllSessions();
 
             var allSessions = new List<SessionDisplayModel>();
-
-            bool showSpeaker = conference.CanShowSpeakers();
+            var showSpeaker = conference.CanShowSpeakers();
 
             foreach (var session in sessions)
             {
@@ -73,7 +72,7 @@ namespace DDDEastAnglia.Controllers
             var userProfile = userProfileRepository.GetUserProfileByUserName(session.SpeakerUserName);
 
             var conference = conferenceLoader.LoadConference();
-            bool showSpeaker = conference.CanShowSpeakers();
+            var showSpeaker = conference.CanShowSpeakers();
 
             var displayModel = CreateDisplayModel(session, userProfile, showSpeaker);
 
@@ -165,7 +164,7 @@ namespace DDDEastAnglia.Controllers
         [UserNameFilter("userName")]
         public ActionResult Delete(string userName, int id = 0)
         {
-            Session session = sessionRepository.Get(id);
+            var session = sessionRepository.Get(id);
 
             if (session == null)
             {
@@ -177,8 +176,11 @@ namespace DDDEastAnglia.Controllers
                 return new HttpUnauthorizedResult();
             }
 
+            var conference = conferenceLoader.LoadConference();
+            var showSpeaker = conference.CanShowSpeakers();
+
             var userProfile = userProfileRepository.GetUserProfileByUserName(session.SpeakerUserName);
-            var displayModel = CreateDisplayModel(session, userProfile, true);
+            var displayModel = CreateDisplayModel(session, userProfile, showSpeaker);
             return View(displayModel);
         }
 

--- a/DDDEastAnglia/Controllers/SessionController.cs
+++ b/DDDEastAnglia/Controllers/SessionController.cs
@@ -201,9 +201,6 @@ namespace DDDEastAnglia.Controllers
         private SessionDisplayModel CreateDisplayModel(Session session, UserProfile profile, bool showSpeaker)
         {
             var isUsersSession = Request.IsAuthenticated && session.SpeakerUserName == User.Identity.Name;
-            var tweetLink = CreateTweetLink(isUsersSession, session.Title,
-                                            Url.Action("Details", "Session", new {id = session.SessionId},
-                                                       Request.Url.Scheme));
 
             var displayModel = new SessionDisplayModel
                 {
@@ -222,24 +219,10 @@ namespace DDDEastAnglia.Controllers
                         }
                     },
 
-                    TweetLink = tweetLink,
                     IsUsersSession = isUsersSession,
                     ShowSpeaker = showSpeaker
                 };
             return displayModel;
-        }
-
-        private SessionTweetLink CreateTweetLink(bool isUsersSession, string sessionTitle, string sessionUrl)
-        {
-            var title = string.Format("Check out {0} session for #dddea - {1} {2}",
-                                      isUsersSession ? "my" : "this",
-                                      sessionTitle, sessionUrl);
-            var tweetLink = new SessionTweetLink
-                {
-                    Title = title,
-                    Url = sessionUrl
-                };
-            return tweetLink;
         }
 
         private bool UserDoesNotOwnSession(string userName, Session session)

--- a/DDDEastAnglia/Controllers/SessionController.cs
+++ b/DDDEastAnglia/Controllers/SessionController.cs
@@ -41,10 +41,12 @@ namespace DDDEastAnglia.Controllers
 
             var allSessions = new List<SessionDisplayModel>();
 
+            bool showSpeaker = conference.CanShowSpeakers();
+
             foreach (var session in sessions)
             {
                 var profile = speakersLookup[session.SpeakerUserName];
-                var displayModel = CreateDisplayModel(session, profile);
+                var displayModel = CreateDisplayModel(session, profile, showSpeaker);
                 allSessions.Add(displayModel);
             }
 
@@ -69,7 +71,11 @@ namespace DDDEastAnglia.Controllers
             }
 
             var userProfile = userProfileRepository.GetUserProfileByUserName(session.SpeakerUserName);
-            var displayModel = CreateDisplayModel(session, userProfile);
+
+            var conference = conferenceLoader.LoadConference();
+            bool showSpeaker = conference.CanShowSpeakers();
+
+            var displayModel = CreateDisplayModel(session, userProfile, showSpeaker);
 
             return View(displayModel);
         }
@@ -172,7 +178,7 @@ namespace DDDEastAnglia.Controllers
             }
 
             var userProfile = userProfileRepository.GetUserProfileByUserName(session.SpeakerUserName);
-            var displayModel = CreateDisplayModel(session, userProfile);
+            var displayModel = CreateDisplayModel(session, userProfile, true);
             return View(displayModel);
         }
 
@@ -192,7 +198,7 @@ namespace DDDEastAnglia.Controllers
             return RedirectToAction("Index");
         }
 
-        private SessionDisplayModel CreateDisplayModel(Session session, UserProfile profile)
+        private SessionDisplayModel CreateDisplayModel(Session session, UserProfile profile, bool showSpeaker)
         {
             var isUsersSession = Request.IsAuthenticated && session.SpeakerUserName == User.Identity.Name;
             var tweetLink = CreateTweetLink(isUsersSession, session.Title,
@@ -217,7 +223,8 @@ namespace DDDEastAnglia.Controllers
                     },
 
                     TweetLink = tweetLink,
-                    IsUsersSession = isUsersSession
+                    IsUsersSession = isUsersSession,
+                    ShowSpeaker = showSpeaker
                 };
             return displayModel;
         }

--- a/DDDEastAnglia/Controllers/SpeakerController.cs
+++ b/DDDEastAnglia/Controllers/SpeakerController.cs
@@ -72,6 +72,13 @@ namespace DDDEastAnglia.Controllers
 
         public ActionResult Details(int id = 0)
         {
+            var conference = conferenceLoader.LoadConference();
+
+            if (!conference.CanShowSpeakers())
+            {
+                return HttpNotFound();
+            }
+
             var speakerProfile = userProfileRepository.GetUserProfileById(id);
 
             if (speakerProfile == null)
@@ -79,7 +86,6 @@ namespace DDDEastAnglia.Controllers
                 return HttpNotFound();
             }
 
-            var conference = conferenceLoader.LoadConference();
             var sessionLoader = sessionLoaderFactory.Create(conference);
             var sessions = sessionLoader.LoadSessions(speakerProfile);
 

--- a/DDDEastAnglia/DDDEastAnglia.csproj
+++ b/DDDEastAnglia/DDDEastAnglia.csproj
@@ -459,7 +459,6 @@
     <Compile Include="Models\ResetPasswordStepThreeModel.cs" />
     <Compile Include="Models\SessionDisplayModel.cs" />
     <Compile Include="Models\SessionIndexModel.cs" />
-    <Compile Include="Models\SessionTweetLink.cs" />
     <Compile Include="Models\SessionVoteModel.cs" />
     <Compile Include="Models\SpeakerDisplayModel.cs" />
     <Content Include="ForgottenPasswordTemplate.txt" />

--- a/DDDEastAnglia/DataAccess/SimpleData/Builders/ConferenceBuilder.cs
+++ b/DDDEastAnglia/DataAccess/SimpleData/Builders/ConferenceBuilder.cs
@@ -22,7 +22,7 @@ namespace DDDEastAnglia.DataAccess.SimpleData.Builders
                 return null;
             }
             
-            var conference = new Domain.Conference(item.ConferenceId, item.Name, item.ShortName, item.NumberOfTimeSlots, item.NumberOfTracks);
+            var conference = new Domain.Conference(item.ConferenceId, item.Name, item.ShortName, item.NumberOfTimeSlots, item.NumberOfTracks, item.AnonymousSessions);
             var calendarItems = calendarItemRepository.GetAll();
 
             foreach (var calendarItem in calendarItems)

--- a/DDDEastAnglia/DataAccess/SimpleData/Models/Conference.cs
+++ b/DDDEastAnglia/DataAccess/SimpleData/Models/Conference.cs
@@ -16,5 +16,7 @@ namespace DDDEastAnglia.DataAccess.SimpleData.Models
         public int NumberOfTimeSlots { get; set; }
 
         public List<CalendarItem> CalendarItems { get; set; }
+
+        public bool AnonymousSessions { get; set; }
     }
 }

--- a/DDDEastAnglia/Domain/Conference.cs
+++ b/DDDEastAnglia/Domain/Conference.cs
@@ -78,12 +78,26 @@ namespace DDDEastAnglia.Domain
 
         public bool CanShowSessions()
         {
-            return CanShowSpeakers();
+            if (anonymousSessions)
+            {
+                return true;
+            }
+            else
+            {
+                return CanShowSpeakers();
+            }
         }
 
         public bool CanShowSpeakers()
         {
-            return ConferenceTimelineIsActive() && (CanSubmit() || CanVote() || CanPublishAgenda() || CanRegister());
+            if (anonymousSessions)
+            {
+                return ConferenceTimelineIsActive() && (CanPublishAgenda() || CanRegister());
+            }
+            else
+            {
+                return ConferenceTimelineIsActive() && (CanSubmit() || CanVote() || CanPublishAgenda() || CanRegister());
+            }
         }
 
         public bool IsPreview()

--- a/DDDEastAnglia/Domain/Conference.cs
+++ b/DDDEastAnglia/Domain/Conference.cs
@@ -10,15 +10,17 @@ namespace DDDEastAnglia.Domain
         private readonly string shortName;
         private readonly int numberOfTimeSlots;
         private readonly int numberOfTracks;
+        private readonly bool anonymousSessions;
         private readonly Dictionary<CalendarEntryType, CalendarEntry> calendarEntries = new Dictionary<CalendarEntryType, CalendarEntry>();
 
-        public Conference(int id, string name, string shortName, int numberOfTimeSlots = 0, int numberOfTracks = 0)
+        public Conference(int id, string name, string shortName, int numberOfTimeSlots = 0, int numberOfTracks = 0, bool anonymousSessions = false)
         {
             this.id = id;
             this.name = name;
             this.shortName = shortName;
             this.numberOfTimeSlots = numberOfTimeSlots;
             this.numberOfTracks = numberOfTracks;
+            this.anonymousSessions = anonymousSessions;
         }
 
         public int Id
@@ -115,6 +117,11 @@ namespace DDDEastAnglia.Domain
             return calendarEntries.TryGetValue(calendarEntryType, out calendarEntry)
                 ? calendarEntry
                 : new NullCalendarEntry();
+        }
+
+        public bool AnonymousSessions()
+        {
+            return this.AnonymousSessions();
         }
     }
 }

--- a/DDDEastAnglia/Domain/Conference.cs
+++ b/DDDEastAnglia/Domain/Conference.cs
@@ -135,7 +135,7 @@ namespace DDDEastAnglia.Domain
 
         public bool AnonymousSessions()
         {
-            return this.AnonymousSessions();
+            return this.anonymousSessions;
         }
     }
 }

--- a/DDDEastAnglia/Domain/Conference.cs
+++ b/DDDEastAnglia/Domain/Conference.cs
@@ -78,14 +78,7 @@ namespace DDDEastAnglia.Domain
 
         public bool CanShowSessions()
         {
-            if (anonymousSessions)
-            {
-                return true;
-            }
-            else
-            {
-                return CanShowSpeakers();
-            }
+            return CanShowSpeakers();
         }
 
         public bool CanShowSpeakers()
@@ -118,7 +111,7 @@ namespace DDDEastAnglia.Domain
         public void AddToCalendar(CalendarEntry entry)
         {
             var calendarEntryType = entry.GetEntryType();
-            
+
             if (calendarEntryType != CalendarEntryType.Unknown)
             {
                 calendarEntries[calendarEntryType] = entry;

--- a/DDDEastAnglia/Domain/Conference.cs
+++ b/DDDEastAnglia/Domain/Conference.cs
@@ -78,19 +78,12 @@ namespace DDDEastAnglia.Domain
 
         public bool CanShowSessions()
         {
-            return CanShowSpeakers();
+            return CanSubmit() || CanVote() || CanPublishAgenda() || CanRegister();
         }
 
         public bool CanShowSpeakers()
         {
-            if (anonymousSessions)
-            {
-                return ConferenceTimelineIsActive() && (CanPublishAgenda() || CanRegister());
-            }
-            else
-            {
-                return ConferenceTimelineIsActive() && (CanSubmit() || CanVote() || CanPublishAgenda() || CanRegister());
-            }
+            return !anonymousSessions && CanShowSessions();
         }
 
         public bool IsPreview()
@@ -124,11 +117,6 @@ namespace DDDEastAnglia.Domain
             return calendarEntries.TryGetValue(calendarEntryType, out calendarEntry)
                 ? calendarEntry
                 : new NullCalendarEntry();
-        }
-
-        public bool AnonymousSessions()
-        {
-            return this.anonymousSessions;
         }
     }
 }

--- a/DDDEastAnglia/Domain/IConference.cs
+++ b/DDDEastAnglia/Domain/IConference.cs
@@ -19,5 +19,6 @@
         bool CanShowSpeakers();
         bool IsPreview();
         bool IsClosed();
+        bool AnonymousSessions();
     }
 }

--- a/DDDEastAnglia/Domain/IConference.cs
+++ b/DDDEastAnglia/Domain/IConference.cs
@@ -19,6 +19,5 @@
         bool CanShowSpeakers();
         bool IsPreview();
         bool IsClosed();
-        bool AnonymousSessions();
     }
 }

--- a/DDDEastAnglia/Models/SessionDisplayModel.cs
+++ b/DDDEastAnglia/Models/SessionDisplayModel.cs
@@ -13,6 +13,7 @@ namespace DDDEastAnglia.Models
         public SessionTweetLink TweetLink { get; set; }
         public bool IsUsersSession { get; set; }
         public bool HasAlreadyBeenVotedFor { get; set; }
+        public bool ShowSpeaker { get; set; }
     }
 
     public class SessionSpeakerModel

--- a/DDDEastAnglia/Models/SessionDisplayModel.cs
+++ b/DDDEastAnglia/Models/SessionDisplayModel.cs
@@ -10,7 +10,6 @@ namespace DDDEastAnglia.Models
 
         public IList<SessionSpeakerModel> Speakers { get; set; }
 
-        public SessionTweetLink TweetLink { get; set; }
         public bool IsUsersSession { get; set; }
         public bool HasAlreadyBeenVotedFor { get; set; }
         public bool ShowSpeaker { get; set; }

--- a/DDDEastAnglia/Models/SessionTweetLink.cs
+++ b/DDDEastAnglia/Models/SessionTweetLink.cs
@@ -1,8 +1,0 @@
-﻿namespace DDDEastAnglia.Models
-{
-    public class SessionTweetLink
-    {
-        public string Title { get; set; }
-        public string Url { get; set; }
-    }
-}

--- a/DDDEastAnglia/Views/Session/Details.cshtml
+++ b/DDDEastAnglia/Views/Session/Details.cshtml
@@ -19,18 +19,6 @@
     }
 </div>
 
-<div class="tweet-session">
-    @if (Model.IsUsersSession)
-    {
-        @Html.TweetButton("Check out my session for #dddea - " + Model.SessionTitle, Request.Url)
-    }
-    else
-    {
-        @Html.TweetButton("Check out this session for #dddea - " + Model.SessionTitle, Request.Url)
-    }
-
-</div>
-
 <div class="abstract">
     @Html.MarkdownFor(model => model.SessionAbstract)
 </div>

--- a/DDDEastAnglia/Views/Session/Details.cshtml
+++ b/DDDEastAnglia/Views/Session/Details.cshtml
@@ -6,18 +6,21 @@
 
 <h2>@Html.DisplayFor(model => model.SessionTitle)</h2>
 
-<div>
-    @foreach (var speaker in Model.Speakers)
-    {
-        <span class="speaker-profile">
-            @if (speaker.SpeakerGravatarUrl != null)
-            {
-                <img src="@speaker.SpeakerGravatarUrl" alt="@speaker.SpeakerName"/>
-            }
-            <a href="@Url.Action("Details", "Speaker", new { id = speaker.SpeakerId })">@(string.IsNullOrWhiteSpace(speaker.SpeakerName) ? speaker.SpeakerUserName : speaker.SpeakerName)</a>
-        </span>
-    }
-</div>
+@if (Model.ShowSpeaker)
+{
+    <div>
+        @foreach (var speaker in Model.Speakers)
+        {
+            <span class="speaker-profile">
+                @if (speaker.SpeakerGravatarUrl != null)
+                {
+                    <img src="@speaker.SpeakerGravatarUrl" alt="@speaker.SpeakerName"/>
+                }
+                <a href="@Url.Action("Details", "Speaker", new { id = speaker.SpeakerId })">@(string.IsNullOrWhiteSpace(speaker.SpeakerName) ? speaker.SpeakerUserName : speaker.SpeakerName)</a>
+            </span>
+        }
+    </div>
+}
 
 <div class="abstract">
     @Html.MarkdownFor(model => model.SessionAbstract)

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -16,10 +16,13 @@
     <h3>
         @Model.SessionTitle
     </h3>
-    <h4>
-        <img src="@Model.Speakers.First().SpeakerGravatarUrl" width="32" height="32" alt="@Model.Speakers.First().SpeakerName">
-        <a href="@Url.Action("Details", "Speaker", new { id = Model.Speakers.First().SpeakerId })">@(string.IsNullOrWhiteSpace(Model.Speakers.First().SpeakerName) ? Model.Speakers.First().SpeakerUserName : Model.Speakers.First().SpeakerName)</a>
-    </h4>
+    @if (Model.ShowSpeaker)
+    {
+        <h4>
+            <img src="@Model.Speakers.First().SpeakerGravatarUrl" width="32" height="32" alt="@Model.Speakers.First().SpeakerName">
+            <a href="@Url.Action("Details", "Speaker", new {id = Model.Speakers.First().SpeakerId})">@(string.IsNullOrWhiteSpace(Model.Speakers.First().SpeakerName) ? Model.Speakers.First().SpeakerUserName : Model.Speakers.First().SpeakerName)</a>
+        </h4>
+    }
     <div class="session-abstract">
         @Html.MarkdownFor(s => Model.SessionAbstract)
     </div>

--- a/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
+++ b/DDDEastAnglia/Views/Session/_SessionDetailsPartial.cshtml
@@ -20,9 +20,6 @@
         <img src="@Model.Speakers.First().SpeakerGravatarUrl" width="32" height="32" alt="@Model.Speakers.First().SpeakerName">
         <a href="@Url.Action("Details", "Speaker", new { id = Model.Speakers.First().SpeakerId })">@(string.IsNullOrWhiteSpace(Model.Speakers.First().SpeakerName) ? Model.Speakers.First().SpeakerUserName : Model.Speakers.First().SpeakerName)</a>
     </h4>
-    <div class="session-tweet">
-        @Html.TweetButton(Model.TweetLink.Title)
-    </div>
     <div class="session-abstract">
         @Html.MarkdownFor(s => Model.SessionAbstract)
     </div>


### PR DESCRIPTION
This adds the ability to make the whole session submission and voting process anonymous. When it is turned on, speaker details will not be shown alongside session details.

I've tested it in both session submission and voting stages and can't find any pages that still show the speaker details when the setting is turned on. They do still show the details when the setting is turned off.